### PR TITLE
cmake errors fix on Debian Jessie

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,10 +23,12 @@ Additionally to the tox build dependencies, you will need:
     cmake (>=2.8.7)
     libgtk-3-dev (>=3.4)
     libgee-0.8-dev (>=0.8)
+    libjson-glib-dev (>=0.14)
+    libsqlite3-dev (>=3.7)
 
 Ubuntu >= 12.10 (Quantal Quetzal) / Linux Mint / Debian:
 
-    apt-get install valac cmake libgtk-3-dev libgee-0.8-dev
+    apt-get install valac cmake libgtk-3-dev libgee-0.8-dev libjson-glib-dev libsqlite3-dev
 
 Ubuntu 12.04 (Precise Pangolin) needs a ppa to get a newer version of valac and libgee-0.8
 


### PR DESCRIPTION
Unable to find libs module errors in cmake went away after I tried this on Debian Jessie. sqlite3 and json-glib-1.0 like it says in the errors referred to the wrong packages.  It's late and I don't know how else to tell you, hope it helps somehow. Thanks for Venom, love the file send GUI, tell me if I fucked something up here
