### PR TITLE
Update INSTALL.md to use homebrew for everything

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,14 +65,9 @@ Follow ProjectTox-Core [installation instructions](https://github.com/irungentoo
 With Homebrew
 -------------
 
-    brew install vala cmake gtk+3 libgee json-glib sqlite
-    git clone git://github.com/naxuroqa/Venom.git
-    cd Venom
-    mkdir build
-    cd build
-    cmake ..
-    make
-    sudo make install
+    brew tap Tox/tox
+    brew install --HEAD libtoxcore
+    brew install --HEAD venom
 
 Windows
 =======


### PR DESCRIPTION
This depends on Tox/homebrew-tox#3, but it should make installing venom easier on Macs with homebrew.
