### PR TITLE
name changes in chat [INCOMPLETE]

### DIFF
--- a/src/core/Message.vala
+++ b/src/core/Message.vala
@@ -195,6 +195,34 @@ namespace Venom {
       return "<b>%s</b> %s".printf(from != null ? Markup.escape_text(from_name) : "me", Markup.escape_text(message));
     }
   }
+  public class NameChangeGroupMessage : GroupMessage {
+    public NameChangeGroupMessage.outgoing(GroupChat receiver, string message, DateTime timestamp = new DateTime.now_local()) {
+      this.from = null;
+      this.to = receiver;
+      this.from_name = null;
+      this.message = message;
+      this.timestamp = timestamp;
+    }
+    public NameChangeGroupMessage.incoming(GroupChat sender, string from_name, string message, DateTime timestamp = new DateTime.now_local()) {
+      this.from = sender;
+      this.to = null;
+      this.from_name = from_name;
+      this.message = message;
+      this.timestamp = timestamp;
+    }
+    public override string get_sender_plain() {
+      return "*";
+    }
+    public override string get_message_plain() {
+      return "%s is now known as %s".printf(from != null ? from_name : "me", message);
+    }
+    public override string get_sender_markup() {
+      return "*";
+    }
+    public override string get_message_markup() {
+      return "<b>%s</b> is now known as <b>%s</b>".printf(from != null ? Markup.escape_text(from_name) : "me", Markup.escape_text(message));
+    }
+  }
   public class FileTransferMessage : IMessage, GLib.Object {
     public FileTransfer file_transfer {get; private set;}
     public DateTime timestamp {get; protected set;}

--- a/src/core/ToxSession.vala
+++ b/src/core/ToxSession.vala
@@ -74,6 +74,7 @@ namespace Venom {
     public signal void on_group_invite(Contact c, GroupChat g);
     public signal void on_group_message(GroupChat g, int peernumber, string message);
     public signal void on_group_action(GroupChat g, int peernumber, string action);
+    public signal void on_group_peer_namechanged(GroupChat g, int peernumber, string old_name);
     public signal void on_group_peer_changed(GroupChat g, int peernumber, Tox.ChatChange change);
 
     // File sending callbacks
@@ -252,6 +253,19 @@ namespace Venom {
     {
       string action_string = ((string)action).dup();
       Idle.add(() => { on_group_action(_groups.get(groupnumber), friendgroupnumber, action_string); return false; });
+    }
+
+    private void on_group_name_change_callback(Tox.Tox tox, int groupnumber, int peernumber, Tox.ChatChange change) {
+      if (change == Tox.ChatChange.PEER_NAME) {
+        GroupChat g = _groups.get(groupnumber);
+        string old_name = group_peername(g, peernumber);
+        Idle.add(() => {
+          g = _groups.get(groupnumber);
+          g.peer_count = group_number_peers(g);
+          on_group_peer_namechanged(g, peernumber, old_name);
+          return false;
+        });
+      }
     }
 
     private void on_group_namelist_change_callback(Tox.Tox tox, int groupnumber, int peernumber, Tox.ChatChange change) {

--- a/src/ui/ContactListWindow.vala
+++ b/src/ui/ContactListWindow.vala
@@ -57,6 +57,7 @@ namespace Venom {
     public signal void incoming_name_change(NameChangeMessage m);
     public signal void incoming_group_message(GroupMessage m);
     public signal void incoming_group_action(GroupActionMessage m);
+    public signal void incoming_group_name_change(NameChangeGroupMessage m);
 
     // Default Constructor
     public ContactListWindow (Gtk.Application application) {
@@ -308,6 +309,7 @@ namespace Venom {
       session.on_group_message.connect(this.on_group_message);
       session.on_group_action.connect(this.on_group_action);
       session.on_group_peer_changed.connect(this.on_group_peer_changed);
+      session.on_group_peer_namechanged.connect(this.on_group_peer_namechanged);
 
       //file signals
       session.on_file_sendrequest.connect(this.on_file_sendrequest);
@@ -672,9 +674,21 @@ namespace Venom {
       this.set_urgency();
     }
 
-    private void on_group_peer_changed(GroupChat g, int peernumber, Tox.ChatChange change) {
+    private void on_group_peer_namechanged(GroupChat g, int peernumber, string old_name) {
       GroupConversationWidget w = open_group_conversation_with(g);
       w.update_contact();
+      string to_name = session.group_peername(g, peernumber);
+      stdout.printf("[gnc] [%i]@%i: %s to %s\n", peernumber, g.group_id, old_name, to_name);
+      incoming_group_name_change(new NameChangeGroupMessage.incoming(g, old_name, to_name));
+      groupchat_changed(g);
+    }
+
+    private void on_group_peer_changed(GroupChat g, int peernumber, Tox.ChatChange change) {
+      GroupConversationWidget w = open_group_conversation_with(g);
+      stdout.printf("[gnc] [%i]@%i: %i\n", peernumber, g.group_id, change.PEER_NAME);
+      w.update_contact();
+      string from_name = session.group_peername(g, peernumber);
+      incoming_group_name_change(new NameChangeGroupMessage.incoming(g, from_name, from_name));
       groupchat_changed(g);
     }
 
@@ -822,6 +836,7 @@ namespace Venom {
         w = new GroupConversationWidget(g);
         incoming_group_message.connect(w.on_incoming_message);
         incoming_group_action.connect(w.on_incoming_message);
+        incoming_group_name_change.connect(w.on_incoming_message);
         w.new_outgoing_message.connect(on_outgoing_group_message);
         w.new_outgoing_action.connect(on_outgoing_group_action);
         group_conversation_widgets[g.group_id] = w;


### PR DESCRIPTION
I'm stuck here. Can't find a way to get old name of peer in the chat. Probably need to store it somehwere, right?
