### PR TITLE
umask such that stored files are u+rw only

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ VALA_PRECOMPILE( VALA_C_VENOM
     sqlite3
     tox-1.0
     config
+    posix
   OPTIONS
     --target-glib=${TARGET_GLIB}
     --thread

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -35,6 +35,7 @@ public class Main : GLib.Object {
 	  };
 
     public static int main (string[] args) {
+      Posix.umask(Posix.S_IRGRP | Posix.S_IWGRP | Posix.S_IROTH | Posix.S_IWOTH);
       try {
 		    GLib.OptionContext option_context = new GLib.OptionContext("");
 		    option_context.set_help_enabled(true);


### PR DESCRIPTION
Specifically the data file should not be read/writable to group/other since it contains the private key.

There are more surgical ways this can be done (chmod'ing in `store_data`), but I don't think there is a downside to being overly protective in this way.
