### PR TITLE
VENOM-331: Fix friend address size not validated

### DIFF
--- a/src/tox/Conference.vala
+++ b/src/tox/Conference.vala
@@ -35,7 +35,7 @@ namespace Venom {
     }
 
     public string get_id() {
-      return "";
+      return @"tox.conference.$conference_number";
     }
 
     public string get_name_string() {

--- a/src/tox/ConferenceMessage.vala
+++ b/src/tox/ConferenceMessage.vala
@@ -27,11 +27,13 @@ namespace Venom {
     public bool is_action                     { get; set; }
     public bool received                      { get; set; }
 
+    public uint32 conference_number           { get; protected set; }
     public string message                     { get; protected set; }
     public string peer_name                   { get; protected set; }
     public string peer_key                    { get; protected set; }
 
-    private ConferenceMessage(MessageDirection direction, string message, GLib.DateTime timestamp) {
+    private ConferenceMessage(uint32 conference_number, MessageDirection direction, string message, GLib.DateTime timestamp) {
+      this.conference_number = conference_number;
       this.message_direction = direction;
       this.message = message;
       this.timestamp = timestamp;
@@ -39,12 +41,12 @@ namespace Venom {
       this.is_action = false;
     }
 
-    public ConferenceMessage.outgoing(string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
-      this(MessageDirection.OUTGOING, message, timestamp);
+    public ConferenceMessage.outgoing(uint32 conference_number, string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
+      this(conference_number, MessageDirection.OUTGOING, message, timestamp);
     }
 
-    public ConferenceMessage.incoming(string peer_key, string peer_name, string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
-      this(MessageDirection.INCOMING, message, timestamp);
+    public ConferenceMessage.incoming(uint32 conference_number, string peer_key, string peer_name, string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
+      this(conference_number, MessageDirection.INCOMING, message, timestamp);
       this.peer_key = peer_key;
       this.peer_name = peer_name;
     }
@@ -58,7 +60,7 @@ namespace Venom {
     }
 
     public string get_sender_id() {
-      return "";
+      return @"tox.conference.$conference_number";
     }
 
     public string get_message_plain() {

--- a/src/tox/ToxAdapterConferenceListener.vala
+++ b/src/tox/ToxAdapterConferenceListener.vala
@@ -121,7 +121,7 @@ namespace Venom {
       var contact = conferences.@get(conference_number) as Conference;
       var conversation = conversations.@get(contact);
       var peer = contact.get_peers().@get(peer_number);
-      var msg = new ConferenceMessage.incoming(peer.peer_key, peer.peer_name, message);
+      var msg = new ConferenceMessage.incoming(conference_number, peer.peer_key, peer.peer_name, message);
       notification_listener.on_unread_message(msg);
       contact.unread_messages++;
       contact.changed();
@@ -132,7 +132,7 @@ namespace Venom {
       logger.d("on_conference_message_sent");
       var contact = conferences.@get(conference_number) as Conference;
       var conversation = conversations.@get(contact);
-      var msg = new ConferenceMessage.outgoing(message);
+      var msg = new ConferenceMessage.outgoing(conference_number, message);
       msg.received = true;
       conversation.append(msg);
     }

--- a/src/tox/ToxSession.vala
+++ b/src/tox/ToxSession.vala
@@ -648,6 +648,9 @@ namespace Venom {
     }
 
     public virtual void friend_add(uint8[] address, string message) throws ToxError {
+      if (address.length != address_size()) {
+        throw new ToxError.GENERIC(_("Address must consist of 76 hexadecimal characters"));
+      }
       var e = ErrFriendAdd.OK;
       var friend_number = handle.friend_add(address, message, out e);
       if (e != ErrFriendAdd.OK) {

--- a/src/ui/file_transfer_widget.ui
+++ b/src/ui/file_transfer_widget.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface domain="venom">
   <requires lib="gtk+" version="3.20"/>
   <template class="VenomFileTransferWidget" parent="GtkBox">
@@ -90,4 +90,40 @@
       </packing>
     </child>
   </template>
+  <object class="GtkBox" id="placeholder">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="halign">center</property>
+    <property name="valign">center</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">6</property>
+    <child>
+      <object class="GtkImage">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="icon_name">document-save-symbolic</property>
+        <property name="icon_size">6</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">No file transfers yet …</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <style>
+      <class name="dim-label"/>
+    </style>
+  </object>
 </interface>

--- a/src/view/FileTransferWidget.vala
+++ b/src/view/FileTransferWidget.vala
@@ -26,8 +26,8 @@ namespace Venom {
     private ObservableList transfers;
     private FileTransferEntryListener listener;
 
-    [GtkChild]
-    private Gtk.ListBox file_transfers;
+    [GtkChild] private Gtk.ListBox file_transfers;
+    [GtkChild] private Gtk.Widget placeholder;
 
     public FileTransferWidget(ILogger logger, ObservableList transfers, FileTransferEntryListener listener) {
       logger.d("FileTransferWidget created.");
@@ -35,6 +35,7 @@ namespace Venom {
       this.transfers = transfers;
       this.listener = listener;
 
+      file_transfers.set_placeholder(placeholder);
       file_transfers.bind_model(new ObservableListModel(transfers), create_entry);
       unmap.connect(() => { file_transfers.bind_model(null, null); } );
     }


### PR DESCRIPTION
* Throw an error if address is not of length TOX_ADDRESS_SIZE
* Added a placeholder for the file transfer widget
* Added a unique id for conferences to open the correct one
  when clicking on notifications

closes #331 