### PR TITLE
VENOM-351: Fix format strings

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,18 +1,21 @@
-[Vala]
+[all]
+ignore = **/build/**
+
+[all.vala]
 bears = SpaceConsistencyBear, FilenameBear
 files = **.vala
 use_spaces = True
 file_naming_convention = pascal
 
-[XML]
+[all.xml]
 bears = XMLBear
 files = **.(ui|xml)
 
-[Git]
+[all.git]
 bears = GitCommitBear
 shortlog_length = 79
 shortlog_regex = ^VENOM-\d+: .*
 
-[PO]
+[all.po]
 bears = DennisBear
 files = **.(po|pot)

--- a/po/es.po
+++ b/po/es.po
@@ -14,7 +14,7 @@ msgstr "Establecer el nivel de mensajes para iniciar sesión"
 
 #: src/core/Application.vala:32
 msgid "<loglevel>"
-msgstr "<nivel de log>"
+msgstr ""
 
 #: src/core/Application.vala:33
 msgid "Display version number"
@@ -22,7 +22,7 @@ msgstr "Mostrar número de versión"
 
 #: src/core/NotificationListener.vala:55
 msgid "New message from %s"
-msgstr "Nuevo mensaje de% s"
+msgstr "Nuevo mensaje de %s"
 
 #: src/core/R.vala:70
 msgid "Tox User"
@@ -30,7 +30,7 @@ msgstr "Usuario de Tox"
 
 #: src/tox/Conference.vala:47
 msgid "%u Peers online"
-msgstr "% u Pares en línea"
+msgstr "%u Pares en línea"
 
 #: src/view/AboutDialog.vala:53
 msgid "Packagers"
@@ -45,9 +45,8 @@ msgid "Visit us on Github"
 msgstr "Visítanos en Github"
 
 #: src/ui/add_contact_widget.ui:43
-#, fuzzy
 msgid "Please let me add you to my contact list. 😁"
-msgstr "Por favor dejame agregarte a mi lista de contactos."
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:99
 msgid "Send a friend request"
@@ -55,21 +54,19 @@ msgstr "Envía un solicitud de amistad"
 
 #: src/ui/add_contact_widget.ui:133
 msgid "_ID:"
-msgstr "_CARNÉ DE IDENTIDAD:"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:150
-#, fuzzy
 msgid "Enter a Tox ID or URI here"
-msgstr "Inserte un Tox ID o un Tox URI aquí"
+msgstr ""
 
 #: src/ui/create_groupchat_widget.ui:113 src/ui/add_contact_widget.ui:154
-#, fuzzy
 msgid "paste from clipboard"
-msgstr "_Copiar ID al portapapeles"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:188
 msgid "<small>Enter your friends Tox ID</small>"
-msgstr "<small> Introduce la ID de Tox de tus amigos </ small>"
+msgstr "<small>Introduce la ID de Tox de tus amigos</small>"
 
 #: src/ui/friend_request_widget.ui:78 src/ui/add_contact_widget.ui:220
 #, fuzzy
@@ -81,9 +78,8 @@ msgid "Send a custom message to be displayed to the friend you are adding"
 msgstr "Envíe un mensaje personalizado para el contacto que está agregando"
 
 #: src/ui/add_contact_widget.ui:268
-#, fuzzy
 msgid "<small>Send your friend a short message</small>"
-msgstr "Mostrar a _otros cuando estoy escribiendo"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:298
 msgid "Send"
@@ -103,9 +99,8 @@ msgid "_Quit"
 msgstr "_Dejar"
 
 #: src/ui/create_groupchat_widget.ui:112 src/ui/conference_info_widget.ui:39
-#, fuzzy
 msgid "Conference"
-msgstr "Abrir preferencias"
+msgstr ""
 
 #: src/ui/conference_info_widget.ui:105
 msgid "Title:"
@@ -135,15 +130,12 @@ msgid "All"
 msgstr "Todo"
 
 #: src/ui/contact_list_widget.ui:329
-#, fuzzy
 msgid "Add a contact"
-msgstr "Añadir contacto"
+msgstr ""
 
 #: src/ui/contact_list_widget.ui:371
-#, fuzzy
 msgid "View file transfers"
-msgstr "Finalizó transferencia de archivo para %s de %s\n"
-""
+msgstr ""
 
 #: src/ui/contact_list_widget.ui:392
 msgid "Open preferences"
@@ -154,9 +146,8 @@ msgid "Start a call"
 msgstr "Comience una llamada"
 
 #: src/ui/conversation_window.ui:290
-#, fuzzy
 msgid "Insert attachment"
-msgstr "Insertar Smiley"
+msgstr ""
 
 #: src/ui/create_groupchat_widget.ui:93
 msgid "_Title:"
@@ -171,14 +162,12 @@ msgid "Create"
 msgstr "Crear"
 
 #: src/ui/file_transfer_widget.ui:35
-#, fuzzy
 msgid "File transfers"
-msgstr "El archivo fue rechazado."
+msgstr ""
 
 #: src/ui/friend_info_widget.ui:45
-#, fuzzy
 msgid "Friend profile"
-msgstr "Enviar archivo"
+msgstr ""
 
 #: src/ui/friend_info_widget.ui:62
 msgid "Remove from your friends list"
@@ -193,9 +182,8 @@ msgid "Image:"
 msgstr "Imagen:"
 
 #: src/ui/friend_info_widget.ui:245
-#, fuzzy
 msgid "Last seen:"
-msgstr "Visto por última vez: %s"
+msgstr ""
 
 #: src/ui/friend_info_widget.ui:290
 msgid "Alias:"
@@ -203,7 +191,7 @@ msgstr "Alias:"
 
 #: src/ui/friend_info_widget.ui:321
 msgid "<small>Set a custom alias to quickly find your friends</small>"
-msgstr "<small> Establece un alias personalizado para encontrar rápidamente a tus amigos </ small>"
+msgstr "<small>Establece un alias personalizado para encontrar rápidamente a tus amigos</small>"
 
 #: src/ui/user_info_widget.ui:291 src/ui/friend_info_widget.ui:579
 msgid "Tox"
@@ -214,14 +202,12 @@ msgid "ID:"
 msgstr "ID:"
 
 #: src/ui/message_widget.ui:91
-#, fuzzy
 msgid "Message sent ✓"
-msgstr "Mensaje demasiado largo"
+msgstr ""
 
 #: src/ui/message_widget.ui:107
-#, fuzzy
 msgid "Message received ✓"
-msgstr "El archivo fue rechazado."
+msgstr ""
 
 #: src/ui/peer_entry.ui:55
 msgid "This peer is also in your friends list"
@@ -256,20 +242,16 @@ msgid "Privacy"
 msgstr "Privacidad"
 
 #: src/ui/settings_widget.ui:663
-#, fuzzy
 msgid "Send typing notifications"
-msgstr "Error en la carga del ícono: %s\n"
-""
+msgstr ""
 
 #: src/ui/settings_widget.ui:676
-#, fuzzy
 msgid "<small>Show others when I am typing</small>"
-msgstr "Mostrar a _otros cuando estoy escribiendo"
+msgstr ""
 
 #: src/ui/settings_widget.ui:759
-#, fuzzy
 msgid "History"
-msgstr "Mantener historial"
+msgstr ""
 
 #: src/ui/settings_widget.ui:893
 msgid "days"
@@ -294,7 +276,7 @@ msgstr "_Copiar ID al portapapeles"
 
 #: src/ui/welcome_widget.ui:40
 msgid "<big>A new kind of instant messaging</big>"
-msgstr "<big> Un nuevo tipo de mensajería instantánea </ big>"
+msgstr "<big>Un nuevo tipo de mensajería instantánea</big>"
 
 #: src/ui/welcome_widget.ui:56
 msgid "Chat with your friends and family without anyone else listening in."
@@ -323,7 +305,7 @@ msgstr "Aceptar petición"
 
 #: src/ui/application_window.ui:55
 msgid "venom"
-msgstr "veneno"
+msgstr ""
 
 #: src/core/NotificationListener.vala:76
 msgid "New file from %s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -22,7 +22,7 @@ msgstr "Afficher le numéro de version"
 
 #: src/core/NotificationListener.vala:55
 msgid "New message from %s"
-msgstr "Nouveau message de% s"
+msgstr "Nouveau message de %s"
 
 #: src/core/R.vala:70
 msgid "Tox User"
@@ -30,7 +30,7 @@ msgstr "Utilisateur de Tox"
 
 #: src/tox/Conference.vala:47
 msgid "%u Peers online"
-msgstr "% u pairs en ligne"
+msgstr "%u pairs en ligne"
 
 #: src/view/AboutDialog.vala:53
 msgid "Packagers"
@@ -66,7 +66,7 @@ msgstr "coller du presse-papiers"
 
 #: src/ui/add_contact_widget.ui:188
 msgid "<small>Enter your friends Tox ID</small>"
-msgstr "<small> Entrez vos amis Tox ID </ small>"
+msgstr "<small>Entrez vos amis Tox ID</small>"
 
 #: src/ui/friend_request_widget.ui:78 src/ui/add_contact_widget.ui:220
 msgid "_Message:"
@@ -78,7 +78,7 @@ msgstr "Envoyez un message personnalisé à l'ami que vous ajoutez"
 
 #: src/ui/add_contact_widget.ui:268
 msgid "<small>Send your friend a short message</small>"
-msgstr "<small> Envoyer un petit message à votre ami </ small>"
+msgstr "<small>Envoyer un petit message à votre ami</small>"
 
 #: src/ui/add_contact_widget.ui:298
 msgid "Send"
@@ -188,7 +188,7 @@ msgstr "Alias:"
 
 #: src/ui/friend_info_widget.ui:321
 msgid "<small>Set a custom alias to quickly find your friends</small>"
-msgstr "<small> Définir un alias personnalisé pour trouver rapidement vos amis </ small>"
+msgstr "<small>Définir un alias personnalisé pour trouver rapidement vos amis</small>"
 
 #: src/ui/user_info_widget.ui:291 src/ui/friend_info_widget.ui:579
 msgid "Tox"
@@ -244,7 +244,7 @@ msgstr "Envoyer des notifications de frappe"
 
 #: src/ui/settings_widget.ui:676
 msgid "<small>Show others when I am typing</small>"
-msgstr "<small> Afficher les autres lorsque je tape </ small>"
+msgstr "<small>Afficher les autres lorsque je tape</small>"
 
 #: src/ui/settings_widget.ui:759
 msgid "History"
@@ -272,7 +272,7 @@ msgstr "Copier dans le presse-papier"
 
 #: src/ui/welcome_widget.ui:40
 msgid "<big>A new kind of instant messaging</big>"
-msgstr "<big> Un nouveau type de messagerie instantanée </ big>"
+msgstr "<big>Un nouveau type de messagerie instantanée</big>"
 
 #: src/ui/welcome_widget.ui:56
 msgid "Chat with your friends and family without anyone else listening in."
@@ -305,7 +305,7 @@ msgstr "venin"
 
 #: src/core/NotificationListener.vala:76
 msgid "New file from %s"
-msgstr "Nouveau fichier de% s"
+msgstr "Nouveau fichier de %s"
 
 #: src/viewmodel/ContactListEntryViewModel.vala:58
 msgid "New Message!"
@@ -331,15 +331,15 @@ msgstr "En ligne"
 
 #: src/viewmodel/MessageViewModel.vala:65
 msgid "Today at %s"
-msgstr "Aujourd'hui à% s"
+msgstr "Aujourd'hui à %s"
 
 #: src/viewmodel/MessageViewModel.vala:69
 msgid "Yesterday at %s"
-msgstr "Hier à% s"
+msgstr "Hier à %s"
 
 #: src/tox/Conference.vala:43
 msgid "Unnamed conference %u"
-msgstr "Conférence sans nom% u"
+msgstr "Conférence sans nom %u"
 
 #: src/tox/ToxSession.vala:645
 msgid "Address must consist of 76 hexadecimal characters"
@@ -347,7 +347,7 @@ msgstr "L'adresse doit comporter 76 caractères hexadécimaux"
 
 #: src/view/ConversationWindow.vala:102
 msgid "%s is typing..."
-msgstr "% s tape ..."
+msgstr "%s tape ..."
 
 #: src/view/ConversationWindow.vala:168 src/view/FileTransferEntry.vala:76
 msgid "_Cancel"
@@ -407,7 +407,7 @@ msgstr "Procuration"
 
 #: src/ui/settings_widget.ui:326
 msgid "<small>Use a dark variant of the theme</small>"
-msgstr "<small> Utiliser une variante sombre du thème </ small>"
+msgstr "<small>Utiliser une variante sombre du thème</small>"
 
 #: src/ui/settings_widget.ui:383
 msgid "Animations"
@@ -415,7 +415,7 @@ msgstr "Animations"
 
 #: src/ui/settings_widget.ui:396
 msgid "<small>Enable animated transitions</small>"
-msgstr "<small> Activer les transitions animées </ small>"
+msgstr "<small>Activer les transitions animées</small>"
 
 #: src/ui/settings_widget.ui:453
 msgid "Notifications"
@@ -423,11 +423,11 @@ msgstr "Notifications"
 
 #: src/ui/settings_widget.ui:466
 msgid "<small>Show notifications for unread messages</small>"
-msgstr "<small> Afficher les notifications pour les messages non lus </ small>"
+msgstr "<small>Afficher les notifications pour les messages non lus</small>"
 
 #: src/ui/settings_widget.ui:536
 msgid "<small>Minimize app to system tray on close</small>"
-msgstr "<small> Réduire l'application à la barre d'état système à proximité </ small>"
+msgstr "<small>Réduire l'application à la barre d'état système à proximité</small>"
 
 #: src/ui/settings_widget.ui:823
 msgid "Keep forever"
@@ -439,7 +439,7 @@ msgstr "Retirer plus de"
 
 #: src/ui/settings_widget.ui:1017
 msgid "<b>Connection</b>"
-msgstr "<b> Connexion </ b>"
+msgstr "<b>Connexion</b>"
 
 #: src/ui/settings_widget.ui:1060
 msgid "UDP"
@@ -451,7 +451,7 @@ msgstr "IPv6"
 
 #: src/ui/settings_widget.ui:1143
 msgid "<small>Allow both IPv4 and IPv6 communication</small>"
-msgstr "<small> Autoriser les communications IPv4 et IPv6 </ small>"
+msgstr "<small>Autoriser les communications IPv4 et IPv6</small>"
 
 #: src/ui/settings_widget.ui:1200
 msgid "Local discovery"
@@ -459,7 +459,7 @@ msgstr "Découverte locale"
 
 #: src/ui/settings_widget.ui:1213
 msgid "<small>Look for peers on the local network</small>"
-msgstr "<small> Rechercher des pairs sur le réseau local </ small>"
+msgstr "<small>Rechercher des pairs sur le réseau local</small>"
 
 #: src/ui/settings_widget.ui:1270
 msgid "Hole punching"
@@ -467,15 +467,15 @@ msgstr "Perforation"
 
 #: src/ui/settings_widget.ui:1283
 msgid "<small>Enable UDP <a href=\"https://en.wikipedia.org/wiki/Hole_punching_(networking)\">hole punching</a></small>"
-msgstr "<small> Activer UDP <a href=\"https://en.wikipedia.org/wiki/Hole_punching_(networking)\"> perforation </a> </ small>"
+msgstr "<small>Activer UDP<a href=\"https://en.wikipedia.org/wiki/Hole_punching_(networking)\">perforation</a></small>"
 
 #: src/ui/settings_widget.ui:1376
 msgid "<b>Bootstrap nodes</b>"
-msgstr "<b> Noeuds Bootstrap </ b>"
+msgstr "<b>Noeuds Bootstrap</b>"
 
 #: src/ui/settings_widget.ui:1511
 msgid "<b>Proxy</b>"
-msgstr "<b> Proxy </ b>"
+msgstr "<b>Proxy</b>"
 
 #: src/ui/settings_widget.ui:1578
 msgid "System settings"
@@ -483,7 +483,7 @@ msgstr "Les paramètres du système"
 
 #: src/ui/settings_widget.ui:1591
 msgid "<small>Use your systems proxy settings</small>"
-msgstr "<small> Utilisez les paramètres de proxy de votre système </ small>"
+msgstr "<small>Utilisez les paramètres de proxy de votre système</small>"
 
 #: src/ui/settings_widget.ui:1645
 msgid "Manual settings"
@@ -491,7 +491,7 @@ msgstr "Paramètres manuels"
 
 #: src/ui/settings_widget.ui:1658
 msgid "<small>Use custom proxy settings</small>"
-msgstr "<small> Utiliser les paramètres de proxy personnalisés </ small>"
+msgstr "<small>Utiliser les paramètres de proxy personnalisés</small>"
 
 #: src/ui/settings_widget.ui:1699
 msgid "Host"
@@ -499,7 +499,7 @@ msgstr "Hôte"
 
 #: src/ui/settings_widget.ui:1739
 msgid "<small>Set a SOCKS5 proxy to connect to</small>"
-msgstr "<small> Définir un proxy SOCKS5 pour se connecter à </ small>"
+msgstr "<small>Définir un proxy SOCKS5 pour se connecter à</small>"
 
 #: src/ui/friend_info_widget.ui:309
 msgid "Reset alias"

--- a/po/it.po
+++ b/po/it.po
@@ -22,7 +22,7 @@ msgstr "Visualizza il numero di versione"
 
 #: src/core/NotificationListener.vala:55
 msgid "New message from %s"
-msgstr "Nuovo messaggio da% s"
+msgstr "Nuovo messaggio da %s"
 
 #: src/core/R.vala:70
 msgid "Tox User"
@@ -30,7 +30,7 @@ msgstr "Utente Tox"
 
 #: src/tox/Conference.vala:47
 msgid "%u Peers online"
-msgstr "% u Peer online"
+msgstr "%u Peer online"
 
 #: src/view/AboutDialog.vala:53
 msgid "Packagers"
@@ -45,9 +45,8 @@ msgid "Visit us on Github"
 msgstr "Visitaci su Github"
 
 #: src/ui/add_contact_widget.ui:43
-#, fuzzy
 msgid "Please let me add you to my contact list. 😁"
-msgstr "Per favore permettimi di aggiungerti alla mia lista contatti."
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:99
 msgid "Send a friend request"
@@ -58,41 +57,36 @@ msgid "_ID:"
 msgstr "_ID:"
 
 #: src/ui/add_contact_widget.ui:150
-#, fuzzy
 msgid "Enter a Tox ID or URI here"
-msgstr "Inserisci un Tox ID o un Tox URI"
+msgstr ""
 
 #: src/ui/create_groupchat_widget.ui:113 src/ui/add_contact_widget.ui:154
-#, fuzzy
 msgid "paste from clipboard"
-msgstr "_Copia Tox ID negli appunti"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:188
 msgid "<small>Enter your friends Tox ID</small>"
-msgstr "<small> Inserisci l'ID Tox dei tuoi amici </ small>"
+msgstr "<small>Inserisci l'ID Tox dei tuoi amici</small>"
 
 #: src/ui/friend_request_widget.ui:78 src/ui/add_contact_widget.ui:220
-#, fuzzy
 msgid "_Message:"
-msgstr "_Messaggio (opzionale):"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:246
 msgid "Send a custom message to be displayed to the friend you are adding"
 msgstr "Invia un messaggio personalizzato che sarà visualizzato dal contatto che stai aggiungendo"
 
 #: src/ui/add_contact_widget.ui:268
-#, fuzzy
 msgid "<small>Send your friend a short message</small>"
-msgstr "Mostra agli altri quando sto scrivendo"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:298
 msgid "Send"
 msgstr "Inviare"
 
 #: src/ui/app_menu.ui:7
-#, fuzzy
 msgid "_Preferences"
-msgstr "Preferenze"
+msgstr ""
 
 #: src/ui/app_menu.ui:13
 msgid "About"
@@ -103,9 +97,8 @@ msgid "_Quit"
 msgstr "_Smettere"
 
 #: src/ui/create_groupchat_widget.ui:112 src/ui/conference_info_widget.ui:39
-#, fuzzy
 msgid "Conference"
-msgstr "Preferenze"
+msgstr ""
 
 #: src/ui/conference_info_widget.ui:105
 msgid "Title:"
@@ -122,9 +115,8 @@ msgstr "Colleghi"
 
 #: src/ui/conference_window.ui:209 src/ui/conversation_window.ui:268
 #: src/ui/user_info_widget.ui:177 src/ui/user_info_widget.ui:178
-#, fuzzy
 msgid "Insert Emoji"
-msgstr "Inserisci emoticon"
+msgstr ""
 
 #: src/ui/contact_list_widget.ui:216
 msgid "Filter contacts by status"
@@ -135,15 +127,12 @@ msgid "All"
 msgstr "Tutti"
 
 #: src/ui/contact_list_widget.ui:329
-#, fuzzy
 msgid "Add a contact"
-msgstr "Aggiungi contatto"
+msgstr ""
 
 #: src/ui/contact_list_widget.ui:371
-#, fuzzy
 msgid "View file transfers"
-msgstr "Trasferimento file finito per %s a %s\n"
-""
+msgstr ""
 
 #: src/ui/contact_list_widget.ui:392
 msgid "Open preferences"
@@ -154,9 +143,8 @@ msgid "Start a call"
 msgstr "Inizia una chiamata"
 
 #: src/ui/conversation_window.ui:290
-#, fuzzy
 msgid "Insert attachment"
-msgstr "Inserisci emoticon"
+msgstr ""
 
 #: src/ui/create_groupchat_widget.ui:93
 msgid "_Title:"
@@ -171,14 +159,12 @@ msgid "Create"
 msgstr "Creare"
 
 #: src/ui/file_transfer_widget.ui:35
-#, fuzzy
 msgid "File transfers"
-msgstr "Il file è stato rifiutato"
+msgstr ""
 
 #: src/ui/friend_info_widget.ui:45
-#, fuzzy
 msgid "Friend profile"
-msgstr "Invia file"
+msgstr ""
 
 #: src/ui/friend_info_widget.ui:62
 msgid "Remove from your friends list"
@@ -193,9 +179,8 @@ msgid "Image:"
 msgstr "Immagine:"
 
 #: src/ui/friend_info_widget.ui:245
-#, fuzzy
 msgid "Last seen:"
-msgstr "Visto l'ultima volta: %s"
+msgstr ""
 
 #: src/ui/friend_info_widget.ui:290
 msgid "Alias:"
@@ -203,7 +188,7 @@ msgstr "Alias:"
 
 #: src/ui/friend_info_widget.ui:321
 msgid "<small>Set a custom alias to quickly find your friends</small>"
-msgstr "<small> Imposta un alias personalizzato per trovare rapidamente i tuoi amici </ small>"
+msgstr "<small>Imposta un alias personalizzato per trovare rapidamente i tuoi amici</small>"
 
 #: src/ui/user_info_widget.ui:291 src/ui/friend_info_widget.ui:579
 msgid "Tox"
@@ -214,14 +199,12 @@ msgid "ID:"
 msgstr "Tox ID:"
 
 #: src/ui/message_widget.ui:91
-#, fuzzy
 msgid "Message sent ✓"
-msgstr "Messaggio troppo lungo"
+msgstr ""
 
 #: src/ui/message_widget.ui:107
-#, fuzzy
 msgid "Message received ✓"
-msgstr "Il file è stato rifiutato"
+msgstr ""
 
 #: src/ui/peer_entry.ui:55
 msgid "This peer is also in your friends list"
@@ -256,20 +239,16 @@ msgid "Privacy"
 msgstr "Privacy"
 
 #: src/ui/settings_widget.ui:663
-#, fuzzy
 msgid "Send typing notifications"
-msgstr "Errore nel caricare l'icona: %s\n"
-""
+msgstr ""
 
 #: src/ui/settings_widget.ui:676
-#, fuzzy
 msgid "<small>Show others when I am typing</small>"
-msgstr "Mostra agli altri quando sto scrivendo"
+msgstr ""
 
 #: src/ui/settings_widget.ui:759
-#, fuzzy
 msgid "History"
-msgstr "Salva cronologia delle chat"
+msgstr ""
 
 #: src/ui/settings_widget.ui:893
 msgid "days"
@@ -288,13 +267,12 @@ msgid "User profile"
 msgstr "Profilo utente"
 
 #: src/ui/user_info_widget.ui:372
-#, fuzzy
 msgid "Copy to clipboard"
-msgstr "_Copia Tox ID negli appunti"
+msgstr ""
 
 #: src/ui/welcome_widget.ui:40
 msgid "<big>A new kind of instant messaging</big>"
-msgstr "<big> Un nuovo tipo di messaggistica istantanea </ big>"
+msgstr "<big>Un nuovo tipo di messaggistica istantanea</big>"
 
 #: src/ui/welcome_widget.ui:56
 msgid "Chat with your friends and family without anyone else listening in."
@@ -327,7 +305,7 @@ msgstr "veleno"
 
 #: src/core/NotificationListener.vala:76
 msgid "New file from %s"
-msgstr "Nuovo file da% s"
+msgstr "Nuovo file da %s"
 
 #: src/viewmodel/ContactListEntryViewModel.vala:58
 msgid "New Message!"
@@ -353,15 +331,15 @@ msgstr "in linea"
 
 #: src/viewmodel/MessageViewModel.vala:65
 msgid "Today at %s"
-msgstr "Oggi a% s"
+msgstr "Oggi a %s"
 
 #: src/viewmodel/MessageViewModel.vala:69
 msgid "Yesterday at %s"
-msgstr "Ieri a% s"
+msgstr "Ieri a %s"
 
 #: src/tox/Conference.vala:43
 msgid "Unnamed conference %u"
-msgstr "Conferenza senza nome% u"
+msgstr "Conferenza senza nome %u"
 
 #: src/tox/ToxSession.vala:645
 msgid "Address must consist of 76 hexadecimal characters"
@@ -369,7 +347,7 @@ msgstr "L'indirizzo deve essere composto da 76 caratteri esadecimali"
 
 #: src/view/ConversationWindow.vala:102
 msgid "%s is typing..."
-msgstr "% s sta scrivendo ..."
+msgstr "%s sta scrivendo ..."
 
 #: src/view/ConversationWindow.vala:168 src/view/FileTransferEntry.vala:76
 msgid "_Cancel"
@@ -429,7 +407,7 @@ msgstr "delega"
 
 #: src/ui/settings_widget.ui:326
 msgid "<small>Use a dark variant of the theme</small>"
-msgstr "<small> Utilizza una variante scura del tema </ small>"
+msgstr "<small>Utilizza una variante scura del tema</small>"
 
 #: src/ui/settings_widget.ui:383
 msgid "Animations"
@@ -437,7 +415,7 @@ msgstr "animazioni"
 
 #: src/ui/settings_widget.ui:396
 msgid "<small>Enable animated transitions</small>"
-msgstr "<small> Abilita transizioni animate </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:453
 msgid "Notifications"
@@ -445,11 +423,11 @@ msgstr "notifiche"
 
 #: src/ui/settings_widget.ui:466
 msgid "<small>Show notifications for unread messages</small>"
-msgstr "<small> Mostra notifiche per messaggi non letti </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:536
 msgid "<small>Minimize app to system tray on close</small>"
-msgstr "<small> Riduci a icona l'app nella barra delle applicazioni alla chiusura </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:823
 msgid "Keep forever"
@@ -461,7 +439,7 @@ msgstr "Rimuovi più vecchio di"
 
 #: src/ui/settings_widget.ui:1017
 msgid "<b>Connection</b>"
-msgstr "<B> Connessione </ b>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1060
 msgid "UDP"
@@ -473,7 +451,7 @@ msgstr "IPv6"
 
 #: src/ui/settings_widget.ui:1143
 msgid "<small>Allow both IPv4 and IPv6 communication</small>"
-msgstr "<small> Consenti entrambe le comunicazioni IPv4 e IPv6 </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1200
 msgid "Local discovery"
@@ -481,7 +459,7 @@ msgstr "Scoperta locale"
 
 #: src/ui/settings_widget.ui:1213
 msgid "<small>Look for peers on the local network</small>"
-msgstr "<small> Cerca i peer sulla rete locale </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1270
 msgid "Hole punching"
@@ -489,15 +467,15 @@ msgstr "Perforazione"
 
 #: src/ui/settings_widget.ui:1283
 msgid "<small>Enable UDP <a href=\"https://en.wikipedia.org/wiki/Hole_punching_(networking)\">hole punching</a></small>"
-msgstr "<small> Abilita UDP <a href=\"https://en.wikipedia.org/wiki/Hole_punching_(networking)\"> perforare </a> </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1376
 msgid "<b>Bootstrap nodes</b>"
-msgstr "<b> Nodi di bootstrap </ b>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1511
 msgid "<b>Proxy</b>"
-msgstr "<B> Proxy </ b>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1578
 msgid "System settings"
@@ -505,7 +483,7 @@ msgstr "Impostazioni di sistema"
 
 #: src/ui/settings_widget.ui:1591
 msgid "<small>Use your systems proxy settings</small>"
-msgstr "<small> Utilizza le impostazioni del proxy di sistema </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1645
 msgid "Manual settings"
@@ -513,7 +491,7 @@ msgstr "Impostazioni manuali"
 
 #: src/ui/settings_widget.ui:1658
 msgid "<small>Use custom proxy settings</small>"
-msgstr "<small> Utilizza le impostazioni proxy personalizzate </ small>"
+msgstr ""
 
 #: src/ui/settings_widget.ui:1699
 msgid "Host"
@@ -521,7 +499,7 @@ msgstr "Ospite"
 
 #: src/ui/settings_widget.ui:1739
 msgid "<small>Set a SOCKS5 proxy to connect to</small>"
-msgstr "<small> Imposta un proxy SOCKS5 per la connessione a </ small>"
+msgstr ""
 
 #: src/ui/friend_info_widget.ui:309
 msgid "Reset alias"

--- a/po/pr.po
+++ b/po/pr.po
@@ -22,7 +22,7 @@ msgstr "Exibir o número da versão"
 
 #: src/core/NotificationListener.vala:55
 msgid "New message from %s"
-msgstr "Nova mensagem de% s"
+msgstr "Nova mensagem de %s"
 
 #: src/core/R.vala:70
 msgid "Tox User"
@@ -30,7 +30,7 @@ msgstr "Usuário Tox"
 
 #: src/tox/Conference.vala:47
 msgid "%u Peers online"
-msgstr "% u Peers online"
+msgstr "%u Peers online"
 
 #: src/view/AboutDialog.vala:53
 msgid "Packagers"
@@ -38,7 +38,7 @@ msgstr "Embaladores"
 
 #: src/view/AboutDialog.vala:58
 msgid "translator-credits"
-msgstr "tradutor-créditos"
+msgstr ""
 
 #: src/view/AboutDialog.vala:61
 msgid "Visit us on Github"
@@ -54,7 +54,7 @@ msgstr "Envie uma solicitação de amizade"
 
 #: src/ui/add_contact_widget.ui:133
 msgid "_ID:"
-msgstr "_IDENTIDADE:"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:150
 msgid "Enter a Tox ID or URI here"
@@ -66,7 +66,7 @@ msgstr "colar da área de transferência"
 
 #: src/ui/add_contact_widget.ui:188
 msgid "<small>Enter your friends Tox ID</small>"
-msgstr "<small> Digite seus amigos Tox ID </ small>"
+msgstr ""
 
 #: src/ui/friend_request_widget.ui:78 src/ui/add_contact_widget.ui:220
 msgid "_Message:"
@@ -78,7 +78,7 @@ msgstr "Envie uma mensagem personalizada a ser exibida para o amigo que você es
 
 #: src/ui/add_contact_widget.ui:268
 msgid "<small>Send your friend a short message</small>"
-msgstr "<small> Envie para o seu amigo uma mensagem curta </ ​​small>"
+msgstr ""
 
 #: src/ui/add_contact_widget.ui:298
 msgid "Send"
@@ -188,7 +188,7 @@ msgstr "Alias:"
 
 #: src/ui/friend_info_widget.ui:321
 msgid "<small>Set a custom alias to quickly find your friends</small>"
-msgstr "<small> Defina um alias personalizado para encontrar rapidamente seus amigos </ small>"
+msgstr "<small>Defina um alias personalizado para encontrar rapidamente seus amigos</small>"
 
 #: src/ui/user_info_widget.ui:291 src/ui/friend_info_widget.ui:579
 msgid "Tox"
@@ -196,7 +196,7 @@ msgstr "Tox"
 
 #: src/ui/user_info_widget.ui:330 src/ui/friend_info_widget.ui:612
 msgid "ID:"
-msgstr "IDENTIDADE:"
+msgstr ""
 
 #: src/ui/message_widget.ui:91
 msgid "Message sent ✓"
@@ -244,7 +244,7 @@ msgstr "Enviar notificações de digitação"
 
 #: src/ui/settings_widget.ui:676
 msgid "<small>Show others when I am typing</small>"
-msgstr "<small> Mostra os outros quando estou digitando </ small>"
+msgstr "<small>Mostra os outros quando estou digitando</small>"
 
 #: src/ui/settings_widget.ui:759
 msgid "History"
@@ -272,7 +272,7 @@ msgstr "Copiar para área de transferência"
 
 #: src/ui/welcome_widget.ui:40
 msgid "<big>A new kind of instant messaging</big>"
-msgstr "<big> Um novo tipo de mensagens instantâneas </ big>"
+msgstr "<big>Um novo tipo de mensagens instantâneas</big>"
 
 #: src/ui/welcome_widget.ui:56
 msgid "Chat with your friends and family without anyone else listening in."
@@ -301,7 +301,7 @@ msgstr "Aceitar pedido"
 
 #: src/ui/application_window.ui:55
 msgid "venom"
-msgstr "veneno"
+msgstr ""
 
 #: src/core/NotificationListener.vala:76
 msgid "New file from %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgstr "Установить уровень логирования"
 
 #: src/core/Application.vala:32
 msgid "<loglevel>"
-msgstr "<LogLevel>"
+msgstr "<loglevel>"
 
 #: src/core/Application.vala:33
 msgid "Display version number"


### PR DESCRIPTION
* Consider warnings in coala, fix malformed format strings in
  automatic translations and discard obviously wrong ones