### PR TITLE
Venom-361: Distribute avatar

### DIFF
--- a/src/core/R.vala
+++ b/src/core/R.vala
@@ -75,7 +75,7 @@ namespace Venom {
       public string user_config_dir { get; set; default = GLib.Environment.get_user_config_dir(); }
       public string downloads_dir { get; set; default = GLib.Environment.get_user_special_dir(GLib.UserDirectory.DOWNLOAD); }
       public string profile_name { get; set; default = "tox"; }
-      public string avatars_folder() { return GLib.Path.build_filename(user_config_dir, "avatars"); }
+      public string avatars_folder() { return GLib.Path.build_filename(user_config_dir, "tox", "avatars"); }
       public string window_state_filename() { return GLib.Path.build_filename(user_config_dir, "tox", profile_name + ".json"); }
       public string db_filename() { return GLib.Path.build_filename(user_config_dir, "tox", profile_name + ".db"); }
       public string tox_data_filename() { return GLib.Path.build_filename(user_config_dir, "tox", profile_name + ".data"); }

--- a/src/core/R.vala
+++ b/src/core/R.vala
@@ -87,10 +87,10 @@ namespace Venom {
     }
   }
 
-  public static Gdk.Pixbuf ? pixbuf_from_resource(string res) {
+  public static Gdk.Pixbuf ? pixbuf_from_resource(string res, int size = 96) {
     try {
       var resource_path = GLib.Path.build_path("/", R.constants.icons_prefix(), res + R.constants.icons_suffix());
-      return new Gdk.Pixbuf.from_resource_at_scale(resource_path, 96, 96, true);
+      return new Gdk.Pixbuf.from_resource_at_scale(resource_path, size, size, true);
     } catch (Error e) {
     }
     return null;

--- a/src/core/UserInfo.vala
+++ b/src/core/UserInfo.vala
@@ -25,17 +25,49 @@ namespace Venom {
 
     public abstract string name { get; set; }
     public abstract string status_message { get; set; }
-    public abstract Gdk.Pixbuf avatar { get; set; }
+    public abstract Avatar avatar { get; set; }
     public abstract bool custom_avatar { get; set; }
     public abstract UserStatus user_status { get; set; }
     public abstract bool is_connected { get; set; }
     public abstract string tox_id { get; set; }
   }
 
+  public class Avatar : GLib.Object {
+    public Gdk.Pixbuf pixbuf { get; set; }
+    public GLib.Bytes hash { get; set; }
+    public Avatar() {
+      reset();
+    }
+
+    public void reset() {
+      pixbuf = pixbuf_from_resource(R.icons.default_contact, 128);
+      hash = new GLib.Bytes(new uint8[] {});
+    }
+
+    public void set_from_data(ILogger logger, uint8[] data, Gdk.Pixbuf? pixbuf = null) throws Error {
+      this.hash = new GLib.Bytes(ToxCore.Tox.hash(data));
+      if (pixbuf != null) {
+        this.pixbuf = pixbuf;
+      } else {
+        var loader = new Gdk.PixbufLoader();
+        try {
+          loader.write(data);
+          loader.close();
+        } catch (Error e) {
+          logger.e("Can not load avatar from data: " + e.message);
+        }
+        unowned Gdk.Pixbuf tmp = loader.get_pixbuf();
+        if (tmp != null) {
+          this.pixbuf = tmp.scale_simple(128, 128, Gdk.InterpType.BILINEAR);
+        }
+      }
+    }
+  }
+
   public class UserInfoImpl : UserInfo, GLib.Object {
     public string name { get; set; }
     public string status_message { get; set; }
-    public Gdk.Pixbuf avatar { get; set; }
+    public Avatar avatar { get; set; }
     public bool custom_avatar { get; set; }
     public UserStatus user_status { get; set; }
     public bool is_connected { get; set; }
@@ -44,7 +76,7 @@ namespace Venom {
     construct {
       name = R.strings.default_username();
       status_message = R.strings.default_statusmessage();
-      avatar = pixbuf_from_resource(R.icons.default_contact, 128);
+      avatar = new Avatar();
       custom_avatar = false;
       user_status = UserStatus.NONE;
       is_connected = false;

--- a/src/core/UserInfo.vala
+++ b/src/core/UserInfo.vala
@@ -21,11 +21,12 @@
 
 namespace Venom {
   public interface UserInfo : GLib.Object {
-    public signal void info_changed(GLib.Object sender);
+    public signal void info_changed();
 
     public abstract string name { get; set; }
     public abstract string status_message { get; set; }
-    public abstract Gdk.Pixbuf image { get; set; }
+    public abstract Gdk.Pixbuf avatar { get; set; }
+    public abstract bool custom_avatar { get; set; }
     public abstract UserStatus user_status { get; set; }
     public abstract bool is_connected { get; set; }
     public abstract string tox_id { get; set; }
@@ -34,7 +35,8 @@ namespace Venom {
   public class UserInfoImpl : UserInfo, GLib.Object {
     public string name { get; set; }
     public string status_message { get; set; }
-    public Gdk.Pixbuf image { get; set; }
+    public Gdk.Pixbuf avatar { get; set; }
+    public bool custom_avatar { get; set; }
     public UserStatus user_status { get; set; }
     public bool is_connected { get; set; }
     public string tox_id { get; set; }
@@ -42,7 +44,8 @@ namespace Venom {
     construct {
       name = R.strings.default_username();
       status_message = R.strings.default_statusmessage();
-      image = pixbuf_from_resource(R.icons.default_contact);
+      avatar = pixbuf_from_resource(R.icons.default_contact, 128);
+      custom_avatar = false;
       user_status = UserStatus.NONE;
       is_connected = false;
       tox_id = "";

--- a/src/testing/TestToxAdapterFiletransferListener.vala
+++ b/src/testing/TestToxAdapterFiletransferListener.vala
@@ -57,7 +57,7 @@ public class TestToxAdapterFiletransferListener : UnitTest {
     Assert.assert_not_null(listener);
     listener.attach_to_session(session);
 
-    mock().verify(session, "set_file_transfer_listener", args().object(listener).create());
+    mock().verify(session, "set_filetransfer_listener", args().object(listener).create());
   }
 
   private void test_start_transfer() throws Error {

--- a/src/testing/mocks/MockToxSession.vala
+++ b/src/testing/mocks/MockToxSession.vala
@@ -33,11 +33,11 @@ namespace Mock {
                      .create();
       mock().actual_call(this, "set_session_listener", args);
     }
-    public void set_file_transfer_listener(ToxAdapterFiletransferListener listener) {
+    public void set_filetransfer_listener(ToxAdapterFiletransferListener listener) {
       var args = Arguments.builder()
                      .object(listener)
                      .create();
-      mock().actual_call(this, "set_file_transfer_listener", args);
+      mock().actual_call(this, "set_filetransfer_listener", args);
     }
     public void set_friend_listener(ToxAdapterFriendListener listener) {
       var args = Arguments.builder()
@@ -190,12 +190,17 @@ namespace Mock {
                      .create();
       mock().actual_call(this, "file_control", args).get_throws();
     }
-    public void file_send(uint32 friend_number, ToxCore.FileKind kind, GLib.File file) throws ToxError {
+    public void file_send_data(uint32 friend_number, GLib.File file) throws ToxError {
       var args = Arguments.builder()
                      .uint(friend_number)
-                     .int(kind)
                      .create();
-      mock().actual_call(this, "file_send", args).get_throws();
+      mock().actual_call(this, "file_send_data", args).get_throws();
+    }
+    public void file_send_avatar(uint32 friend_number, uint8[] avatar_data) throws ToxError {
+      var args = Arguments.builder()
+                     .uint(friend_number)
+                     .create();
+      mock().actual_call(this, "file_send_avatar", args).get_throws();
     }
     public void file_send_chunk(uint32 friend_number, uint32 file_number, uint64 position, uint8[] data) throws ToxError {
       mock().actual_call(this, "file_send_chunk").get_throws();

--- a/src/testing/mocks/MockToxSession.vala
+++ b/src/testing/mocks/MockToxSession.vala
@@ -89,6 +89,10 @@ namespace Mock {
       mock().actual_call(this, "self_get_address");
       return new uint8[0];
     }
+    public uint8[] self_get_public_key() {
+      mock().actual_call(this, "self_get_public_key");
+      return new uint8[0];
+    }
     public void self_get_friend_list_foreach(GetFriendListCallback callback) throws ToxError {
       mock().actual_call(this, "self_get_friend_list_foreach").get_throws();
     }

--- a/src/tox/ToxAdapterFiletransferListener.vala
+++ b/src/tox/ToxAdapterFiletransferListener.vala
@@ -20,14 +20,6 @@
  */
 
 namespace Venom {
-  public interface FileTransferEntryListener : GLib.Object {
-    public abstract void start_transfer(FileTransfer transfer) throws Error;
-    public abstract void stop_transfer(FileTransfer transfer) throws Error;
-    public abstract void pause_transfer(FileTransfer transfer) throws Error;
-    public abstract void remove_transfer(FileTransfer transfer) throws Error;
-    public abstract IContact get_contact_from_transfer(FileTransfer transfer) throws Error;
-  }
-
   public class ToxAdapterFiletransferListenerImpl : ToxAdapterFiletransferListener, FileTransferEntryListener, ConversationWidgetFiletransferListener, GLib.Object {
     private const int MAX_AVATAR_SIZE = 64 * 1024;
 
@@ -55,7 +47,7 @@ namespace Venom {
 
     public virtual void attach_to_session(ToxSession session) {
       this.session = session;
-      session.set_file_transfer_listener(this);
+      session.set_filetransfer_listener(this);
       friends = session.get_friends();
     }
 
@@ -102,7 +94,7 @@ namespace Venom {
     public virtual void on_start_filetransfer(IContact contact, File file) throws Error {
       logger.d("on_start_filetransfer");
       var c = contact as Contact;
-      session.file_send(c.tox_friend_number, ToxCore.FileKind.DATA, file);
+      session.file_send_data(c.tox_friend_number, file);
     }
 
     public virtual void on_file_chunk_request(uint32 friend_number, uint32 file_number, uint64 position, uint64 length) {
@@ -132,23 +124,22 @@ namespace Venom {
       }
     }
 
-    public virtual void on_file_send_received(uint32 friend_number, uint32 file_number, ToxCore.FileKind kind, uint64 file_size, string file_name, GLib.File file) {
-      logger.d("on_file_send_received");
+    public virtual void on_file_send_avatar_received(uint32 friend_number, uint32 file_number, uint8[] avatar_data) {
+      logger.d("on_file_send_avatar_received");
+      var transfer = new FileTransferImpl.AvatarOutgoing(FileTransferDirection.OUTGOING, friend_number, file_number, avatar_data);
+      set_file_transfer(friend_number, file_number, transfer);
+    }
+
+    public virtual void on_file_send_data_received(uint32 friend_number, uint32 file_number, uint64 file_size, string file_name, GLib.File file) {
+      logger.d("on_file_send_data_received");
       try {
-        logger.d("file_control resume sent");
-        FileTransfer transfer;
-        if (kind == ToxCore.FileKind.AVATAR) {
-          transfer = new FileTransferImpl.Avatar(FileTransferDirection.OUTGOING, friend_number, file_number, file_size);
-        } else {
-          transfer = new FileTransferImpl.File(FileTransferDirection.OUTGOING, friend_number, file_number, file_size, file_name);
-        }
+        var transfer = new FileTransferImpl.File(FileTransferDirection.OUTGOING, friend_number, file_number, file_size, file_name);
         transfer.init_file(file);
 
         set_file_transfer(friend_number, file_number, transfer);
         transfers.append(transfer);
       } catch (Error e) {
         logger.e("file_control failed: " + e.message);
-        return;
       }
     }
 
@@ -160,7 +151,7 @@ namespace Venom {
         return;
       }
       var state = file_transfer.get_state();
-      if (state != FileTransferState.RUNNING && state != FileTransferState.PAUSED) {
+      if (state != FileTransferState.INIT && state != FileTransferState.RUNNING && state != FileTransferState.PAUSED) {
         logger.e("Received file control packet, but filetransfer is not paused/running");
         return;
       }

--- a/src/tox/ToxAdapterFiletransferListener.vala
+++ b/src/tox/ToxAdapterFiletransferListener.vala
@@ -20,10 +20,6 @@
  */
 
 namespace Venom {
-  public interface ConversationWidgetFiletransferListener : GLib.Object {
-    public abstract void on_start_filetransfer(IContact contact, File file) throws Error;
-  }
-
   public interface FileTransferEntryListener : GLib.Object {
     public abstract void start_transfer(FileTransfer transfer) throws Error;
     public abstract void stop_transfer(FileTransfer transfer) throws Error;

--- a/src/tox/ToxAdapterSelfListener.vala
+++ b/src/tox/ToxAdapterSelfListener.vala
@@ -24,11 +24,14 @@ namespace Venom {
     private unowned ToxSession session;
     private ILogger logger;
     private UserInfo user_info;
+    private GLib.File avatar_file;
+    private GLib.Cancellable avatar_cancellable;
 
     public ToxAdapterSelfListenerImpl(ILogger logger, UserInfo user_info) {
       logger.d("ToxAdapterSelfListenerImpl created.");
       this.logger = logger;
       this.user_info = user_info;
+      this.avatar_cancellable = new Cancellable();
     }
 
     ~ToxAdapterSelfListenerImpl() {
@@ -40,8 +43,12 @@ namespace Venom {
       session.set_session_listener(this);
 
       user_info.tox_id = Tools.bin_to_hexstring(session.self_get_address());
+
+      var public_key = Tools.bin_to_hexstring(session.self_get_public_key());
+      var avatar_file_path = GLib.Path.build_filename(R.constants.avatars_folder(), public_key + ".png");
+      avatar_file = GLib.File.new_for_path(avatar_file_path);
+
       get_user_info();
-      user_info.info_changed();
     }
 
     public virtual void set_self_name(string name) throws GLib.Error {
@@ -57,16 +64,55 @@ namespace Venom {
     }
 
     public virtual void set_self_avatar(Gdk.Pixbuf pixbuf) throws GLib.Error {
-      logger.d("set_self_avatar TODO set avatar");
+      logger.d("ToxAdapterSelfListenerImpl set_self_avatar");
+      avatar_cancellable.cancel();
+      avatar_cancellable.reset();
+      uint8[] buf;
+      pixbuf.save_to_buffer(out buf, "png");
+      //var hash = session.hash(buf);
+      var bytes = new Bytes(buf);
+      avatar_file.replace_contents_bytes_async.begin(bytes, null, false, GLib.FileCreateFlags.REPLACE_DESTINATION, avatar_cancellable);
+
+      user_info.avatar = pixbuf;
+      user_info.custom_avatar = true;
+      user_info.info_changed();
     }
+
     public virtual void reset_self_avatar() throws GLib.Error {
-      logger.d("reset_self_avatar TODO reset avatar");
+      logger.d("ToxAdapterSelfListenerImpl reset_self_avatar");
+      avatar_cancellable.cancel();
+      avatar_cancellable.reset();
+      if (user_info.custom_avatar) {
+        if (avatar_file.query_exists()) {
+          avatar_file.delete_async.begin(GLib.Priority.DEFAULT, avatar_cancellable);
+        }
+
+        user_info.avatar = pixbuf_from_resource(R.icons.default_contact, 128);
+        user_info.custom_avatar = false;
+        user_info.info_changed();
+      }
+    }
+
+    private async void load_avatar(Cancellable? cancellable = null) {
+      try {
+        var stream = avatar_file.read(cancellable);
+        user_info.avatar = yield new Gdk.Pixbuf.from_stream_at_scale_async(stream, 128, 128, true, cancellable);
+        user_info.custom_avatar = true;
+        user_info.info_changed();
+      } catch (GLib.Error e) {
+        logger.e("Can not load avatar: " + e.message);
+      }
     }
 
     private void get_user_info() {
       user_info.name = session.self_get_name();
       user_info.status_message = session.self_get_status_message();
       user_info.user_status = session.self_get_user_status();
+      if (avatar_file.query_exists()) {
+        load_avatar.begin(avatar_cancellable);
+      } else {
+        user_info.info_changed();
+      }
     }
 
     public void on_self_connection_status_changed(bool is_connected) {

--- a/src/tox/ToxAdapterSelfListener.vala
+++ b/src/tox/ToxAdapterSelfListener.vala
@@ -20,7 +20,7 @@
  */
 
 namespace Venom {
-  public class ToxAdapterSelfListenerImpl : ToxAdapterSelfListener, GLib.Object {
+  public class ToxAdapterSelfListenerImpl : ToxAdapterSelfListener, UserInfoViewListener, GLib.Object {
     private unowned ToxSession session;
     private ILogger logger;
     private UserInfo user_info;
@@ -29,8 +29,6 @@ namespace Venom {
       logger.d("ToxAdapterSelfListenerImpl created.");
       this.logger = logger;
       this.user_info = user_info;
-
-      user_info.info_changed.connect(on_user_info_changed);
     }
 
     ~ToxAdapterSelfListenerImpl() {
@@ -43,7 +41,26 @@ namespace Venom {
 
       user_info.tox_id = Tools.bin_to_hexstring(session.self_get_address());
       get_user_info();
-      user_info.info_changed(this);
+      user_info.info_changed();
+    }
+
+    public virtual void set_self_name(string name) throws GLib.Error {
+      session.self_set_user_name(name);
+      user_info.name = name;
+      user_info.info_changed();
+    }
+
+    public virtual void set_self_status_message(string status_message) throws GLib.Error {
+      session.self_set_status_message(status_message);
+      user_info.status_message = status_message;
+      user_info.info_changed();
+    }
+
+    public virtual void set_self_avatar(Gdk.Pixbuf pixbuf) throws GLib.Error {
+      logger.d("set_self_avatar TODO set avatar");
+    }
+    public virtual void reset_self_avatar() throws GLib.Error {
+      logger.d("reset_self_avatar TODO reset avatar");
     }
 
     private void get_user_info() {
@@ -52,25 +69,15 @@ namespace Venom {
       user_info.user_status = session.self_get_user_status();
     }
 
-    private void on_user_info_changed(GLib.Object sender) {
-      if (sender == this) {
-        return;
-      }
-
-      logger.d("on_user_info_changed.");
-      session.self_set_user_name(user_info.name);
-      session.self_set_status_message(user_info.status_message);
-    }
-
     public void on_self_connection_status_changed(bool is_connected) {
       user_info.is_connected = is_connected;
-      user_info.info_changed(this);
+      user_info.info_changed();
     }
 
     public void self_set_user_status(UserStatus status) {
       session.self_set_user_status(status);
       user_info.user_status = status;
-      user_info.info_changed(this);
+      user_info.info_changed();
     }
   }
 }

--- a/src/tox/ToxContact.vala
+++ b/src/tox/ToxContact.vala
@@ -77,7 +77,7 @@ namespace Venom {
     }
 
     public Gdk.Pixbuf get_image() {
-      return tox_image ?? pixbuf_from_resource(R.icons.default_contact);
+      return tox_image ?? pixbuf_from_resource(R.icons.default_contact, 128);
     }
 
     public bool get_requires_attention() {

--- a/src/tox/ToxSession.vala
+++ b/src/tox/ToxSession.vala
@@ -64,6 +64,7 @@ namespace Venom {
     public abstract UserStatus self_get_user_status();
 
     public abstract uint8[] self_get_address();
+    public abstract uint8[] self_get_public_key();
 
     public abstract void self_get_friend_list_foreach(GetFriendListCallback callback) throws ToxError;
     public abstract void friend_add(uint8[] address, string message) throws ToxError;
@@ -578,6 +579,10 @@ namespace Venom {
 
     public virtual uint8[] self_get_address() {
       return handle.self_get_address();
+    }
+
+    public virtual uint8[] self_get_public_key() {
+      return handle.self_get_public_key();
     }
 
     public virtual void self_set_status_message(string status) {

--- a/src/tox/ToxSession.vala
+++ b/src/tox/ToxSession.vala
@@ -50,7 +50,7 @@ namespace Venom {
 
   public interface ToxSession : GLib.Object {
     public abstract void set_session_listener(ToxAdapterSelfListener listener);
-    public abstract void set_file_transfer_listener(ToxAdapterFiletransferListener listener);
+    public abstract void set_filetransfer_listener(ToxAdapterFiletransferListener listener);
     public abstract void set_friend_listener(ToxAdapterFriendListener listener);
     public abstract void set_conference_listener(ToxAdapterConferenceListener listener);
 
@@ -87,7 +87,8 @@ namespace Venom {
     public abstract string conference_get_title(uint32 conference_number) throws ToxError;
 
     public abstract void file_control(uint32 friend_number, uint32 file_number, FileControl control) throws ToxError;
-    public abstract void file_send(uint32 friend_number, FileKind kind, GLib.File file) throws ToxError;
+    public abstract void file_send_data(uint32 friend_number, GLib.File file) throws ToxError;
+    public abstract void file_send_avatar(uint32 friend_number, uint8[] avatar_data) throws ToxError;
     public abstract void file_send_chunk(uint32 friend_number, uint32 file_number, uint64 position, uint8[] data) throws ToxError;
 
     public abstract unowned GLib.HashTable<uint32, IContact> get_friends();
@@ -134,7 +135,8 @@ namespace Venom {
     public abstract void on_file_recv_control(uint32 friend_number, uint32 file_number, FileControl control);
 
     public abstract void on_file_chunk_request(uint32 friend_number, uint32 file_number, uint64 position, uint64 length);
-    public abstract void on_file_send_received(uint32 friend_number, uint32 file_number, FileKind kind, uint64 file_size, string file_name, GLib.File file);
+    public abstract void on_file_send_data_received(uint32 friend_number, uint32 file_number, uint64 file_size, string file_name, GLib.File file);
+    public abstract void on_file_send_avatar_received(uint32 friend_number, uint32 file_number, uint8[] avatar_data);
   }
 
   public class ToxSessionImpl : GLib.Object, ToxSession {
@@ -152,7 +154,7 @@ namespace Venom {
     private ToxAdapterSelfListener self_listener;
     private ToxAdapterFriendListener friend_listener;
     private ToxAdapterConferenceListener conference_listener;
-    private ToxAdapterFiletransferListener file_transfer_listener;
+    private ToxAdapterFiletransferListener filetransfer_listener;
     private ToxSessionIO iohandler;
     private GLib.HashTable<uint32, IContact> friends;
 
@@ -333,8 +335,8 @@ namespace Venom {
       this.self_listener = listener;
     }
 
-    public virtual void set_file_transfer_listener(ToxAdapterFiletransferListener listener) {
-      this.file_transfer_listener = listener;
+    public virtual void set_filetransfer_listener(ToxAdapterFiletransferListener listener) {
+      this.filetransfer_listener = listener;
     }
 
     public virtual void set_friend_listener(ToxAdapterFriendListener listener) {
@@ -509,10 +511,10 @@ namespace Venom {
       session.logger.d(@"on_file_recv_cb: $friend_number:$file_number ($kind_type_str) $kiB kiB");
       switch (kind_type) {
         case FileKind.DATA:
-          Idle.add(() => { session.file_transfer_listener.on_file_recv_data(friend_number, file_number, file_size, filename_str); return false; });
+          Idle.add(() => { session.filetransfer_listener.on_file_recv_data(friend_number, file_number, file_size, filename_str); return false; });
           break;
         case FileKind.AVATAR:
-          Idle.add(() => { session.file_transfer_listener.on_file_recv_avatar(friend_number, file_number, file_size); return false; });
+          Idle.add(() => { session.filetransfer_listener.on_file_recv_avatar(friend_number, file_number, file_size); return false; });
           break;
       }
     }
@@ -521,20 +523,20 @@ namespace Venom {
       var session = (ToxSessionImpl) user_data;
       session.logger.d(@"on_file_recv_chunk_cb: $friend_number:$file_number $position");
       var data_copy = copy_data(data, data.length);
-      Idle.add(() => { session.file_transfer_listener.on_file_recv_chunk(friend_number, file_number, position, data_copy); return false; });
+      Idle.add(() => { session.filetransfer_listener.on_file_recv_chunk(friend_number, file_number, position, data_copy); return false; });
     }
 
     private static void on_file_recv_control_cb(Tox self, uint32 friend_number, uint32 file_number, FileControl control, void* user_data) {
       var session = (ToxSessionImpl) user_data;
       var control_str = control.to_string();
       session.logger.d(@"on_file_recv_control_cb: $friend_number:$file_number $control_str");
-      Idle.add(() => { session.file_transfer_listener.on_file_recv_control(friend_number, file_number, control); return false; });
+      Idle.add(() => { session.filetransfer_listener.on_file_recv_control(friend_number, file_number, control); return false; });
     }
 
     private static void on_file_chunk_request_cb(Tox self, uint32 friend_number, uint32 file_number, uint64 position, size_t length, void* user_data) {
       var session = (ToxSessionImpl) user_data;
       session.logger.d(@"on_file_chunk_request_cb: $friend_number:$file_number $position $length");
-      Idle.add(() => { session.file_transfer_listener.on_file_chunk_request(friend_number, file_number, position, length); return false; });
+      Idle.add(() => { session.filetransfer_listener.on_file_chunk_request(friend_number, file_number, position, length); return false; });
     }
 
     private static bool from_connection(Connection connection_status) {
@@ -710,17 +712,27 @@ namespace Venom {
       }
     }
 
-    public virtual void file_send(uint32 friend_number, FileKind kind, GLib.File file) throws ToxError {
+    public virtual void file_send_avatar(uint32 friend_number, uint8[] avatar_data) throws ToxError {
+      var e = ErrFileSend.OK;
+      var ret = handle.file_send(friend_number, FileKind.AVATAR, avatar_data.length, null, "", out e);
+      if (e != ErrFileSend.OK) {
+        logger.e("file send avatar request failed: " + e.to_string());
+        throw new ToxError.GENERIC(e.to_string());
+      }
+      filetransfer_listener.on_file_send_avatar_received(friend_number, ret, avatar_data);
+    }
+
+    public virtual void file_send_data(uint32 friend_number, GLib.File file) throws ToxError {
       uint64 file_size = Tools.get_file_size(file);
       var file_name = file.get_basename();
 
       var e = ErrFileSend.OK;
-      var ret = handle.file_send(friend_number, kind, file_size, null, file_name, out e);
+      var ret = handle.file_send(friend_number, FileKind.DATA, file_size, null, file_name, out e);
       if (e != ErrFileSend.OK) {
         logger.e("file send request failed: " + e.to_string());
         throw new ToxError.GENERIC(e.to_string());
       }
-      file_transfer_listener.on_file_send_received(friend_number, ret, kind, file_size, file_name, file);
+      filetransfer_listener.on_file_send_data_received(friend_number, ret, file_size, file_name, file);
     }
 
     public virtual void file_send_chunk(uint32 friend_number, uint32 file_number, uint64 position, uint8[] data) throws ToxError {

--- a/src/ui/conference_window.ui
+++ b/src/ui/conference_window.ui
@@ -90,6 +90,9 @@
                 <property name="icon_name">face-smile-symbolic</property>
               </object>
             </child>
+            <style>
+              <class name="image-button"/>
+            </style>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/src/ui/friend_info_widget.ui
+++ b/src/ui/friend_info_widget.ui
@@ -197,7 +197,7 @@
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Image:</property>
+                            <property name="label" translatable="yes">Avatar:</property>
                             <property name="xalign">0</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
@@ -214,8 +214,9 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="pixel_size">50</property>
+                            <property name="pixel_size">128</property>
                             <property name="icon_name">friend-symbolic</property>
+                            <property name="icon_size">0</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/src/ui/user_info_widget.ui
+++ b/src/ui/user_info_widget.ui
@@ -2,44 +2,6 @@
 <!-- Generated with glade 3.22.1 -->
 <interface domain="venom">
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkSizeGroup"/>
-  <object class="GtkFileFilter" id="imagefilter">
-    <mime-types>
-      <mime-type>image/*</mime-type>
-    </mime-types>
-  </object>
-  <object class="GtkFileChooserDialog" id="imagechooser">
-    <property name="can_focus">False</property>
-    <property name="type_hint">dialog</property>
-    <property name="filter">imagefilter</property>
-    <child internal-child="vbox">
-      <object class="GtkBox">
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
-    </child>
-  </object>
   <template class="VenomUserInfoWidget" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -200,35 +162,19 @@
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Image:</property>
-                            <property name="xalign">0</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
                           <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="orientation">vertical</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkImage" id="image_userimage">
+                              <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="pixel_size">50</property>
-                                <property name="icon_name">friend-symbolic</property>
+                                <property name="label" translatable="yes">Avatar:</property>
+                                <property name="xalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -237,12 +183,22 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFileChooserButton" id="filechooser">
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">False</property>
-                                <property name="no_show_all">True</property>
-                                <property name="dialog">imagechooser</property>
-                                <property name="title" translatable="yes">Choose an avatar</property>
+                              <object class="GtkButton" id="reset_avatar">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="tooltip_text" translatable="yes">Reset avatar</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="icon_name">edit-clear-all-symbolic</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="image-button"/>
+                                  <class name="destructive-action"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -254,6 +210,46 @@
                           </object>
                           <packing>
                             <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage" id="avatar">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="icon_name">friend-symbolic</property>
+                                <property name="icon_size">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFileChooserButton" id="filechooser">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">Choose an avatar</property>
+                                <property name="title" translatable="yes">Choose an avatar</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
                             <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
@@ -375,6 +371,9 @@
                                     <property name="icon_name">edit-copy-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="image-button"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -457,4 +456,5 @@
       </packing>
     </child>
   </template>
+  <object class="GtkSizeGroup"/>
 </interface>

--- a/src/ui/user_info_widget.ui
+++ b/src/ui/user_info_widget.ui
@@ -225,8 +225,12 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
+                                <property name="pixel_size">128</property>
                                 <property name="icon_name">friend-symbolic</property>
                                 <property name="icon_size">0</property>
+                                <style>
+                                  <class name="avatar"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/src/ui/user_info_widget.ui
+++ b/src/ui/user_info_widget.ui
@@ -2,6 +2,108 @@
 <!-- Generated with glade 3.22.1 -->
 <interface domain="venom">
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkSizeGroup"/>
+  <object class="GtkPopover" id="popover1">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">6</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkFlowBox" id="avatars">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="column_spacing">6</property>
+            <property name="row_spacing">6</property>
+            <property name="min_children_per_line">4</property>
+            <property name="max_children_per_line">5</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkButton" id="reset_avatar">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Reset</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">edit-clear-all-symbolic</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="image-button"/>
+                  <class name="destructive-action"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="take_picture">
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Take a picture</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">camera-photo-symbolic</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="image-button"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFileChooserButton" id="filechooser">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Choose a file</property>
+                <property name="title" translatable="yes">Choose an avatar</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <template class="VenomUserInfoWidget" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -162,51 +264,14 @@
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox">
+                          <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Avatar:</property>
-                                <property name="xalign">0</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="reset_avatar">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes">Reset avatar</property>
-                                <child>
-                                  <object class="GtkImage">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">edit-clear-all-symbolic</property>
-                                  </object>
-                                </child>
-                                <style>
-                                  <class name="image-button"/>
-                                  <class name="destructive-action"/>
-                                </style>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="label" translatable="yes">Avatar:</property>
+                            <property name="xalign">0</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -215,16 +280,16 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox">
+                          <object class="GtkMenuButton">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">6</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">start</property>
+                            <property name="popover">popover1</property>
                             <child>
                               <object class="GtkImage" id="avatar">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="halign">start</property>
                                 <property name="pixel_size">128</property>
                                 <property name="icon_name">friend-symbolic</property>
                                 <property name="icon_size">0</property>
@@ -232,28 +297,10 @@
                                   <class name="avatar"/>
                                 </style>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFileChooserButton" id="filechooser">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Choose an avatar</property>
-                                <property name="title" translatable="yes">Choose an avatar</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
+                            <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
@@ -460,5 +507,4 @@
       </packing>
     </child>
   </template>
-  <object class="GtkSizeGroup"/>
 </interface>

--- a/src/view/ApplicationWindow.vala
+++ b/src/view/ApplicationWindow.vala
@@ -97,7 +97,7 @@ namespace Venom {
       notification_listener.clear_notifications();
 
       session_listener = new ToxAdapterSelfListenerImpl(logger, user_info);
-      friend_listener = new ToxAdapterFriendListenerImpl(logger, contacts, friend_requests, conversations, notification_listener);
+      friend_listener = new ToxAdapterFriendListenerImpl(logger, user_info, contacts, friend_requests, conversations, notification_listener);
       conference_listener = new ToxAdapterConferenceListenerImpl(logger, contacts, conference_invites, conversations, notification_listener);
       filetransfer_listener = new ToxAdapterFiletransferListenerImpl(logger, transfers, notification_listener);
 

--- a/src/view/ApplicationWindow.vala
+++ b/src/view/ApplicationWindow.vala
@@ -267,7 +267,7 @@ namespace Venom {
     }
 
     private void on_show_user() {
-      switch_content_with(() => { return new UserInfoWidget(logger, this, user_info); });
+      switch_content_with(() => { return new UserInfoWidget(logger, this, user_info, session_listener); });
     }
 
     private void on_create_groupchat() {

--- a/src/view/ConversationWindow.vala
+++ b/src/view/ConversationWindow.vala
@@ -223,6 +223,10 @@ namespace Venom {
     }
   }
 
+  public interface ConversationWidgetFiletransferListener : GLib.Object {
+    public abstract void on_start_filetransfer(IContact contact, File file) throws Error;
+  }
+
   public class TextViewEventHandler {
     public signal void send();
 

--- a/src/viewmodel/ContactListViewModel.vala
+++ b/src/viewmodel/ContactListViewModel.vala
@@ -122,7 +122,7 @@ namespace Venom {
     private void refresh_user_info(GLib.Object sender) {
       username = user_info.name;
       statusmessage = user_info.status_message;
-      var userimage_pixbuf = scalePixbuf(user_info.avatar);
+      var userimage_pixbuf = scalePixbuf(user_info.avatar.pixbuf);
       if (userimage_pixbuf != null) {
         userimage = userimage_pixbuf;
       }

--- a/src/viewmodel/ContactListViewModel.vala
+++ b/src/viewmodel/ContactListViewModel.vala
@@ -122,7 +122,7 @@ namespace Venom {
     private void refresh_user_info(GLib.Object sender) {
       username = user_info.name;
       statusmessage = user_info.status_message;
-      var userimage_pixbuf = scalePixbuf(user_info.image);
+      var userimage_pixbuf = scalePixbuf(user_info.avatar);
       if (userimage_pixbuf != null) {
         userimage = userimage_pixbuf;
       }

--- a/src/viewmodel/FileTransferEntryViewModel.vala
+++ b/src/viewmodel/FileTransferEntryViewModel.vala
@@ -155,4 +155,12 @@ namespace Venom {
       logger.d("FileTransferEntryViewModel destroyed.");
     }
   }
+
+  public interface FileTransferEntryListener : GLib.Object {
+    public abstract void start_transfer(FileTransfer transfer) throws Error;
+    public abstract void stop_transfer(FileTransfer transfer) throws Error;
+    public abstract void pause_transfer(FileTransfer transfer) throws Error;
+    public abstract void remove_transfer(FileTransfer transfer) throws Error;
+    public abstract IContact get_contact_from_transfer(FileTransfer transfer) throws Error;
+  }
 }

--- a/src/viewmodel/FriendInfoViewModel.vala
+++ b/src/viewmodel/FriendInfoViewModel.vala
@@ -65,7 +65,7 @@ namespace Venom {
       tox_id = contact.get_id();
       var pixbuf = contact.get_image();
       if (pixbuf != null) {
-        userimage = pixbuf.scale_simple(96, 96, Gdk.InterpType.BILINEAR);
+        userimage = pixbuf.scale_simple(128, 128, Gdk.InterpType.BILINEAR);
       }
       auto_conference = contact.auto_conference;
       auto_filetransfer = contact.auto_filetransfer;


### PR DESCRIPTION
* Add a file chooser for avatars
* Set avatar resolution to 128x128
* Add a filter for images to filechooser
* Add callbacks to ToxAdapterSelfListener
* Fix tox avatars directory position
* Fix bug in FileTransferListener preventing user from sending files
* Rework user_info_widget, add avatars from `/usr/share/pixmaps/faces`
* Send avatar to all online contacts immediately
* Send to offline contacts when they come online

closes #361 