### PR TITLE
VENOM-384: Implement tox identicons

### DIFF
--- a/src/core/Identicon.vala
+++ b/src/core/Identicon.vala
@@ -1,0 +1,126 @@
+/*
+ *    Identicon.vala
+ *
+ *    Copyright (C) 2018 Venom authors and contributors
+ *
+ *    This file is part of Venom.
+ *
+ *    Venom is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Venom is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with Venom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Venom {
+  public class Identicon : GLib.Object {
+    private uint8[] hash;
+    private int width;
+    private int height;
+
+    private Cairo.Context ctx;
+    private Cairo.Surface surface;
+
+    public static Gdk.Pixbuf generate_pixbuf(uint8[] public_key) {
+      var identicon = new Identicon(public_key);
+      identicon.draw();
+      return identicon.get_pixbuf();
+    }
+
+    public Identicon(uint8[] public_key) {
+      this.hash = generate_hash(public_key);
+      this.width = 120;
+      this.height = 120;
+      this.surface = new Cairo.ImageSurface(Cairo.Format.RGB24, width, height);
+      this.ctx = new Cairo.Context(surface);
+    }
+
+    public void draw() {
+      var rgb1 = hsl_to_rgb(hue_color(hue_uint(hash, 26)));
+      var rgb2 = hsl_to_rgb(hue_color(hue_uint(hash, 20)), 0.5f, 0.8f);
+
+      ctx.scale(width / 5f, height / 5f);
+
+      for (var row = 0; row < 5; row++) {
+        for (var col = 0; col < 5; col++) {
+          var col_idx = (((col * 2) - 4) / 2).abs();
+          var pos = row * 3 + col_idx;
+          if (hash[pos] % 2 == 0) {
+            ctx.set_source_rgb(rgb1[0] / 255f, rgb1[1] / 255f, rgb1[2] / 255f);
+          } else {
+            ctx.set_source_rgb(rgb2[0] / 255f, rgb2[1] / 255f, rgb2[2] / 255f);
+          }
+          ctx.rectangle(col, row, 1, 1);
+          ctx.fill();
+        }
+      }
+    }
+
+    public void write_to_png(string filename) {
+      surface.write_to_png(filename);
+    }
+
+    public Gdk.Pixbuf get_pixbuf() {
+      return Gdk.pixbuf_get_from_surface(surface, 0, 0, width, height);
+    }
+
+    public uint8[] generate_hash(uint8[] public_key) {
+      return Tools.hexstring_to_bin(Checksum.compute_for_data(ChecksumType.SHA256, public_key));
+    }
+
+    public uint64 hue_uint(uint8[] hash, uint offset) {
+      unowned uint8[] hashpart_1 = hash[offset : offset + 6];
+      uint64 hue = hashpart_1[0];
+      hue = (hue << 8) + (hashpart_1[1] & 0xff);
+      hue = (hue << 8) + (hashpart_1[2] & 0xff);
+      hue = (hue << 8) + (hashpart_1[3] & 0xff);
+      hue = (hue << 8) + (hashpart_1[4] & 0xff);
+      hue = (hue << 8) + (hashpart_1[5] & 0xff);
+      return hue;
+    }
+
+    public float hue_color(uint64 hue_uint) {
+      return hue_uint / 281474976710655.0f;
+    }
+
+    private float hue_to_rgb(float p, float q, float t) {
+      if (t < 0) {
+        t += 1;
+      }
+      if (t > 1) {
+        t -= 1;
+      }
+      if (t < 1 / 6f) {
+        return p + (q - p) * 6 * t;
+      }
+      if (t < 1 / 2f) {
+        return q;
+      }
+      if (t < 2 / 3f) {
+        return p + (q - p) * (2 / 3f - t) * 6;
+      }
+      return p;
+    }
+
+    public uint8[] hsl_to_rgb(float h, float s = 0.5f, float l = 0.3f) {
+      float r, g, b;
+      if (s == 0) {
+        r = g = b = l;
+      } else {
+        var q = l < 0.5f ? l * (1 + s) : l + s - l * s;
+        var p = 2 * l - q;
+        r = hue_to_rgb(p, q, h + 1 / 3f);
+        g = hue_to_rgb(p, q, h);
+        b = hue_to_rgb(p, q, h - 1 / 3f);
+      }
+      return { (uint8) (r * 255), (uint8) (g * 255), (uint8) (b * 255) };
+    }
+  }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,6 +38,7 @@ venom_source = files(
 			'core/Contact.vala',
 			'core/FileIO.vala',
 			'core/FileTransfer.vala',
+			'core/Identicon.vala',
 			'core/Interfaces.vala',
 			'core/Logger.vala',
 			'core/Message.vala',

--- a/src/testing/TestIdenticon.vala
+++ b/src/testing/TestIdenticon.vala
@@ -1,0 +1,103 @@
+/*
+ *    TestIdenticon.vala
+ *
+ *    Copyright (C) 2018 Venom authors and contributors
+ *
+ *    This file is part of Venom.
+ *
+ *    Venom is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Venom is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with Venom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Venom;
+using Mock;
+using Testing;
+
+public class TestIdenticon : UnitTest {
+  private ILogger logger;
+  private uint8[] key;
+  private uint8[] expected_hash;
+
+  public TestIdenticon() {
+    add_func("/test_hash", test_hash);
+    add_func("/test_hue_color", test_hue_color);
+    add_func("/test_hue_color2", test_hue_color2);
+    add_func("/test_rgb_color", test_rgb_color);
+    add_func("/test_rgb_color2", test_rgb_color2);
+    add_func("/test_draw_identicon", test_draw_identicon);
+  }
+
+  public override void set_up() throws Error {
+    logger = new MockLogger();
+    key = {
+      0x76, 0x51, 0x84, 0x06, 0xF6, 0xA9, 0xF2, 0x21,
+      0x7E, 0x8D, 0xC4, 0x87, 0xCC, 0x78, 0x3C, 0x25,
+      0xCC, 0x16, 0xA1, 0x5E, 0xB3, 0x6F, 0xF3, 0x2E,
+      0x33, 0x5A, 0x23, 0x53, 0x42, 0xC4, 0x8A, 0x39
+    };
+    expected_hash = {
+      0xec, 0xac, 0x37, 0x54, 0xec, 0xe2, 0xa2, 0x29,
+      0xdc, 0x40, 0xf0, 0xad, 0xff, 0x6e, 0x30, 0x41,
+      0xb8, 0xce, 0x4a, 0x44, 0xc8, 0xec, 0x3b, 0xd7,
+      0x78, 0xf9, 0x0d, 0xfd, 0x35, 0x29, 0xe5, 0xb7
+    };
+  }
+
+  private void test_hash() throws Error {
+    var identicon = new Identicon(key);
+    var hash = identicon.generate_hash(key);
+    Assert.assert_array_equals(expected_hash, hash);
+  }
+
+  private void test_hue_color() throws Error {
+    var identicon = new Identicon(key);
+    var hue_uint = identicon.hue_uint(expected_hash, 26);
+    Assert.assert_true(15381169825207 == hue_uint);
+    var hue_color = identicon.hue_color(hue_uint);
+    Assert.assert_true(0.054644894f == hue_color);
+  }
+
+  private void test_hue_color2() throws Error {
+    var identicon = new Identicon(key);
+    var hue_uint = identicon.hue_uint(expected_hash, 20);
+    Assert.assert_true(220916941814009 == hue_uint);
+    var hue_color = identicon.hue_color(hue_uint);
+    Assert.assert_true(0.78485465f == hue_color);
+  }
+
+  private void test_rgb_color() throws Error {
+    var identicon = new Identicon(key);
+    var rgb = identicon.hsl_to_rgb(0.054644894f);
+    Assert.assert_array_equals({ 114, 63, 38 }, rgb);
+  }
+
+  private void test_rgb_color2() throws Error {
+    var identicon = new Identicon(key);
+    var rgb = identicon.hsl_to_rgb(0.78485465f, 0.5f, 0.8f);
+    Assert.assert_array_equals({ 214, 178, 229 }, rgb);
+  }
+
+  private void test_draw_identicon() throws Error {
+    var identicon = new Identicon(key);
+    identicon.draw();
+    Assert.assert_not_null(identicon.get_pixbuf());
+  }
+
+  private static int main(string[] args) {
+    Test.init(ref args);
+    var test = new TestIdenticon();
+    (test);
+    Test.run();
+    return 0;
+  }
+}

--- a/src/testing/meson.build
+++ b/src/testing/meson.build
@@ -29,6 +29,12 @@ test_glib_testing = executable('test_glib_testing', ['TestGlibTesting.vala'],
 			dependencies : [gio_dep]
 			)
 
+test_identicon = executable('test_identicon', ['TestIdenticon.vala',
+			'mocks/MockLogger.vala'
+			],
+			dependencies : [venom_dep, mox_dep]
+			)
+
 test_observable_list = executable('test_observable_list', ['TestObservableList.vala',
 			join_paths(root_source_dir, 'core/ObservableList.vala'),
 			join_paths(root_source_dir, 'core/Interfaces.vala')],
@@ -144,6 +150,7 @@ test_undo = executable('test_undo', ['TestUndo.vala'],
 			)
 
 test('test glib', test_glib_testing)
+test('test identicon', test_identicon)
 test('test mocking framework', test_mock)
 test('test tox core vapi', test_tox_core)
 test('test tox transfer', test_tox_transfer)

--- a/src/testing/util/Assert.vala
+++ b/src/testing/util/Assert.vala
@@ -55,6 +55,12 @@ namespace Testing {
       if (o == null) { fail("Object is null"); }
     }
 
+    public static void assert_array_equals(uint8[] expected, uint8[] actual) throws AssertionError {
+      if (expected.length != actual.length || Memory.cmp(expected, actual, expected.length) != 0) {
+        fail("expected != actual");
+      }
+    }
+
     public static void assert_equals<T>(T expected, T actual) throws AssertionError {
       var f = Gee.Functions.get_equal_func_for(typeof(T));
       if (!f(expected, actual)) { fail("expected != actual"); }

--- a/src/tox/ConferenceMessage.vala
+++ b/src/tox/ConferenceMessage.vala
@@ -1,7 +1,7 @@
 /*
  *    ConferenceMessage.vala
  *
- *    Copyright (C) 2018  Venom authors and contributors
+ *    Copyright (C) 2018 Venom authors and contributors
  *
  *    This file is part of Venom.
  *
@@ -80,7 +80,11 @@ namespace Venom {
     }
 
     public Gdk.Pixbuf get_sender_image() {
-      return pixbuf_from_resource(R.icons.default_contact);
+      if (message_direction == MessageDirection.OUTGOING) {
+        return pixbuf_from_resource(R.icons.default_contact);
+      }
+      var pub_key = Tools.hexstring_to_bin(peer_key);
+      return Identicon.generate_pixbuf(pub_key);
     }
 
     public bool equals_sender(IMessage m) {

--- a/src/tox/FriendRequest.vala
+++ b/src/tox/FriendRequest.vala
@@ -23,16 +23,19 @@ namespace Venom {
   public class FriendRequest : GLib.Object {
     public string id { get; set; }
     public string message { get; set; }
+    public DateTime timestamp { get; set; }
 
     public FriendRequest(string id, string message) {
       this.id = id;
       this.message = message;
+      this.timestamp = new DateTime.now_local();
     }
   }
 
   public class ConferenceInvite : GLib.Object {
     public IContact sender { get; set; }
     public ConferenceType conference_type { get; set; }
+    public DateTime timestamp { get; set; }
     public uint8[] get_cookie() {
       return cookie;
     }
@@ -41,6 +44,7 @@ namespace Venom {
       this.sender = sender;
       this.conference_type = conference_type;
       this.cookie = cookie;
+      this.timestamp = new DateTime.now_local();
     }
   }
 }

--- a/src/tox/ToxAdapterFiletransferListener.vala
+++ b/src/tox/ToxAdapterFiletransferListener.vala
@@ -326,16 +326,16 @@ namespace Venom {
             if (file.query_exists()) {
               file.@delete();
             }
-            contact.tox_image = null;
-            contact.changed();
+            var pub_key = Tools.hexstring_to_bin(contact.tox_id);
+            contact.tox_image = Identicon.generate_pixbuf(pub_key);
           } else {
             file.replace_contents(buf, null, false, FileCreateFlags.NONE, null);
             var pixbuf_loader = new Gdk.PixbufLoader();
             pixbuf_loader.write(buf);
             pixbuf_loader.close();
             contact.tox_image = pixbuf_loader.get_pixbuf();
-            contact.changed();
           }
+          contact.changed();
         } catch (Error e) {
           logger.e("set image failed: " + e.message);
         }

--- a/src/tox/ToxAdapterFriendListener.vala
+++ b/src/tox/ToxAdapterFriendListener.vala
@@ -225,7 +225,9 @@ namespace Venom {
 
       var filepath = GLib.Path.build_filename(R.constants.avatars_folder(), @"$str_id.png");
       var file = File.new_for_path(filepath);
-      if (file.query_exists()) {
+      if (!file.query_exists()) {
+        contact.tox_image = Identicon.generate_pixbuf(public_key);
+      } else {
         uint8[] buf;
         try {
           file.load_contents(null, out buf, null);

--- a/src/ui/conference_invite_entry.ui
+++ b/src/ui/conference_invite_entry.ui
@@ -38,7 +38,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">center</property>
-            <property name="pixel_size">24</property>
+            <property name="pixel_size">44</property>
             <property name="icon_name">friend-symbolic</property>
           </object>
           <packing>
@@ -59,15 +59,11 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="contact_description">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Invite from:</property>
-                    <property name="use_underline">True</property>
+                    <property name="label">contact_description</property>
                     <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -76,11 +72,14 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="contact_name">
+                  <object class="GtkLabel" id="contact_time">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label">contact_name</property>
+                    <property name="label">contact_time</property>
                     <property name="xalign">0</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/src/ui/contact_list_entry.ui
+++ b/src/ui/contact_list_entry.ui
@@ -42,9 +42,6 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="pixel_size">48</property>
             <property name="icon_name">friend-symbolic</property>
             <property name="icon_size">5</property>
-            <style>
-              <class name="avatar"/>
-            </style>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/src/ui/contact_list_request_entry.ui
+++ b/src/ui/contact_list_request_entry.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1
+<!-- Generated with glade 3.22.1 
 
 Copyright (C) 2013-2018 Venom authors and contributors
 

--- a/src/ui/friend_request_widget.ui
+++ b/src/ui/friend_request_widget.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1
+<!-- Generated with glade 3.22.1 
 
 Copyright (C) 2013-2018 Venom authors and contributors
 
@@ -34,7 +34,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
         <property name="border_width">6</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkImage">
+          <object class="GtkImage" id="contact_image">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">end</property>
@@ -58,17 +58,17 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="contact_id">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">_Public key:</property>
-                    <property name="use_underline">True</property>
+                    <property name="label">contact_id</property>
+                    <property name="selectable">True</property>
+                    <property name="ellipsize">end</property>
                     <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
+                    <style>
+                      <class name="monospace"/>
+                    </style>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -77,14 +77,14 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="contact_id">
+                  <object class="GtkLabel" id="contact_time">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label">contact_id</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">contact_time</property>
+                    <property name="ellipsize">end</property>
                     <property name="xalign">0</property>
                     <style>
-                      <class name="monospace"/>
+                      <class name="dim-label"/>
                     </style>
                   </object>
                   <packing>
@@ -94,57 +94,21 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="contact_message">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">_Message:</property>
-                    <property name="use_underline">True</property>
+                    <property name="label">contact_message</property>
+                    <property name="wrap">True</property>
                     <property name="xalign">0</property>
+                    <property name="yalign">0</property>
                     <attributes>
-                      <attribute name="weight" value="bold"/>
+                      <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="height_request">100</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkLabel" id="contact_message">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">6</property>
-                        <property name="margin_right">6</property>
-                        <property name="margin_top">6</property>
-                        <property name="margin_bottom">6</property>
-                        <property name="label">contact_message</property>
-                        <property name="wrap">True</property>
-                        <property name="wrap_mode">word-char</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <style>
-                      <class name="frame"/>
-                      <class name="content"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
@@ -158,32 +122,8 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
+                <property name="valign">center</property>
                 <property name="spacing">6</property>
-                <child>
-                  <object class="GtkButton" id="reject">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Reject request</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">user-trash-symbolic</property>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="destructive-action"/>
-                      <class name="image-button"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
                 <child>
                   <object class="GtkButton" id="accept">
                     <property name="visible">True</property>
@@ -199,6 +139,30 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                     </child>
                     <style>
                       <class name="suggested-action"/>
+                      <class name="image-button"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="reject">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Reject request</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">user-trash-symbolic</property>
+                      </object>
+                    </child>
+                    <style>
+                      <class name="destructive-action"/>
                       <class name="image-button"/>
                     </style>
                   </object>

--- a/src/ui/peer_entry_compact.ui
+++ b/src/ui/peer_entry_compact.ui
@@ -33,17 +33,28 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
         <property name="can_focus">False</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkImage" id="peer_self">
+          <object class="GtkImage" id="peer_image">
+            <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="no_show_all">True</property>
-            <property name="tooltip_text" translatable="yes">That's you</property>
-            <property name="icon_name">avatar-default-symbolic</property>
+            <property name="stock">gtk-missing-image</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="peer_name">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label">peer_name</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -57,20 +68,21 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="pack_type">end</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="peer_name">
-            <property name="visible">True</property>
+          <object class="GtkImage" id="peer_self">
             <property name="can_focus">False</property>
-            <property name="label">peer_name</property>
-            <property name="xalign">0</property>
+            <property name="no_show_all">True</property>
+            <property name="tooltip_text" translatable="yes">That's you</property>
+            <property name="icon_name">avatar-default-symbolic</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/src/view/ConferenceInviteEntry.vala
+++ b/src/view/ConferenceInviteEntry.vala
@@ -27,7 +27,8 @@ namespace Venom {
     private ConferenceInviteEntryListener listener;
 
     [GtkChild] private Gtk.Image contact_image;
-    [GtkChild] private Gtk.Label contact_name;
+    [GtkChild] private Gtk.Label contact_description;
+    [GtkChild] private Gtk.Label contact_time;
 
     [GtkChild] private Gtk.Button accept;
     [GtkChild] private Gtk.Button reject;
@@ -42,9 +43,10 @@ namespace Venom {
 
       var pixbuf = sender.get_image();
       if (pixbuf != null) {
-        contact_image.pixbuf = pixbuf.scale_simple(24, 24, Gdk.InterpType.BILINEAR);
+        contact_image.pixbuf = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
       }
-      contact_name.label = sender.get_name_string();
+      contact_description.label = _("Invite from %s").printf(sender.get_name_string());
+      contact_time.label = TimeStamp.get_pretty_timestamp(invite.timestamp);
 
       accept.clicked.connect(on_accept_clicked);
       reject.clicked.connect(on_reject_clicked);

--- a/src/view/ConversationWindow.vala
+++ b/src/view/ConversationWindow.vala
@@ -117,7 +117,7 @@ namespace Venom {
       app_window.header_bar.subtitle = contact.get_status_string();
       var pixbuf = contact.get_image();
       if (pixbuf != null) {
-        user_image.pixbuf = pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR);
+        user_image.pixbuf = round_corners(pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR));
       }
       typing_label.label = _("%s is typing…").printf(contact.get_name_string());
       typing_revealer.reveal_child = contact.is_typing();

--- a/src/view/FriendRequestWidget.vala
+++ b/src/view/FriendRequestWidget.vala
@@ -28,6 +28,8 @@ namespace Venom {
 
     [GtkChild] private Gtk.Label contact_id;
     [GtkChild] private Gtk.Label contact_message;
+    [GtkChild] private Gtk.Label contact_time;
+    [GtkChild] private Gtk.Image contact_image;
 
     [GtkChild] private Gtk.Button accept;
     [GtkChild] private Gtk.Button reject;
@@ -40,6 +42,10 @@ namespace Venom {
 
       contact_id.label = friend_request.id;
       contact_message.label = friend_request.message;
+      contact_time.label = TimeStamp.get_pretty_timestamp(friend_request.timestamp);
+      var pub_key = Tools.hexstring_to_bin(friend_request.id);
+      contact_image.pixbuf = round_corners(Identicon.generate_pixbuf(pub_key).scale_simple(44, 44, Gdk.InterpType.BILINEAR));
+
       accept.clicked.connect(on_accept_clicked);
       reject.clicked.connect(on_reject_clicked);
     }

--- a/src/view/PeerEntry.vala
+++ b/src/view/PeerEntry.vala
@@ -36,6 +36,10 @@ namespace Venom {
       peer_key.label = peer.peer_key;
       peer_known.visible = peer.is_known;
       peer_self.visible = peer.is_self;
+
+      var pub_key = Tools.hexstring_to_bin(peer.peer_key);
+      var pixbuf = Identicon.generate_pixbuf(pub_key);
+      peer_image.pixbuf = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
       logger.d("PeerEntry created.");
     }
 
@@ -45,6 +49,7 @@ namespace Venom {
   }
   [GtkTemplate(ui = "/chat/tox/venom/ui/peer_entry_compact.ui")]
   public class PeerEntryCompact : Gtk.ListBoxRow {
+    [GtkChild] private Gtk.Image peer_image;
     [GtkChild] private Gtk.Label peer_name;
     [GtkChild] private Gtk.Image peer_known;
     [GtkChild] private Gtk.Image peer_self;
@@ -56,6 +61,10 @@ namespace Venom {
       peer_name.label = peer.peer_name;
       peer_known.visible = peer.is_known;
       peer_self.visible = peer.is_self;
+
+      var pub_key = Tools.hexstring_to_bin(peer.peer_key);
+      var pixbuf = Identicon.generate_pixbuf(pub_key);
+      peer_image.pixbuf = round_corners(pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR));
       logger.d("PeerEntryCompact created.");
     }
 

--- a/src/viewmodel/ContactListEntryViewModel.vala
+++ b/src/viewmodel/ContactListEntryViewModel.vala
@@ -51,7 +51,7 @@ namespace Venom {
 
       var pixbuf = contact.get_image();
       if (pixbuf != null) {
-        contact_image = pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR);
+        contact_image = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
       }
 
       if (contact_requires_attention) {
@@ -67,7 +67,7 @@ namespace Venom {
     }
 
     private string tooltip_from_status(UserStatus status) {
-      switch(status) {
+      switch (status) {
         case UserStatus.AWAY:
           return _("Away");
         case UserStatus.BUSY:
@@ -91,5 +91,26 @@ namespace Venom {
     ~ContactListEntryViewModel() {
       logger.d("ContactListEntryViewModel destroyed.");
     }
+  }
+
+  public static Gdk.Pixbuf round_corners(Gdk.Pixbuf source) {
+    var width = source.width;
+    var height = source.height;
+    var radius = width * 0.1f;
+    var surface = new Cairo.ImageSurface(Cairo.Format.ARGB32, width, height);
+    var context = new Cairo.Context(surface);
+    var deg = Math.PI / 180.0;
+
+    context.new_sub_path();
+    context.arc(width - radius, radius, radius, -90 * deg, 0);
+    context.arc(width - radius, height - radius, radius, 0, 90 * deg);
+    context.arc(radius, height - radius, radius, 90 * deg, 180 * deg);
+    context.arc(radius, radius, radius, 180 * deg, 270 * deg);
+    context.close_path();
+
+    Gdk.cairo_set_source_pixbuf(context, source, 0, 0);
+    context.fill();
+
+    return Gdk.pixbuf_get_from_surface(surface, 0, 0, width, height);
   }
 }

--- a/src/viewmodel/ContactListViewModel.vala
+++ b/src/viewmodel/ContactListViewModel.vala
@@ -164,7 +164,7 @@ namespace Venom {
       if (pixbuf == null) {
         return null;
       }
-      return pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR);
+      return round_corners(pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR));
     }
 
     ~ContactListViewModel() {

--- a/src/viewmodel/MessageViewModel.vala
+++ b/src/viewmodel/MessageViewModel.vala
@@ -91,7 +91,7 @@ namespace Venom {
       message = message_content.get_message_plain();
       var pixbuf = message_content.get_sender_image();
       if (pixbuf != null) {
-        sender_image = pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR);
+        sender_image = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
       }
       timestamp = TimeStamp.get_pretty_timestamp(message_content.timestamp);
       timestamp_tooltip = message_content.timestamp.format("%c");


### PR DESCRIPTION
* Add tox reference algorithm for identicons
* Add unit tests
* Add a `round_corners` function to round the corners of a Pixbuf
  with a radius of 10% of the width/height
* Add usage of identicons for conference peers as well

fixes #384 