### PR TITLE
VENOM-125: Add option for compact contact list

### DIFF
--- a/src/core/Application.vala
+++ b/src/core/Application.vala
@@ -112,6 +112,7 @@ namespace Venom {
     }
 
     protected override void shutdown() {
+      settingsDatabase.save();
       Gtk.AccelMap.save(R.constants.accels_filename());
       base.shutdown();
     }

--- a/src/db/DatabaseInterfaces.vala
+++ b/src/db/DatabaseInterfaces.vala
@@ -38,6 +38,7 @@ namespace Venom {
     public abstract bool   enable_ipv6                 { get; set; }
     public abstract bool   enable_local_discovery      { get; set; }
     public abstract bool   enable_hole_punching        { get; set; }
+    public abstract bool   enable_compact_contacts     { get; set; }
 
     public abstract void load();
     public abstract void save();

--- a/src/db/SqliteSettingsDatabase.vala
+++ b/src/db/SqliteSettingsDatabase.vala
@@ -1,7 +1,7 @@
 /*
  *    SqliteSettingsDatabase.vala
  *
- *    Copyright (C) 2013-2018  Venom authors and contributors
+ *    Copyright (C) 2013-2018 Venom authors and contributors
  *
  *    This file is part of Venom.
  *
@@ -38,100 +38,36 @@ namespace Venom {
     public bool   enable_ipv6                 { get; set; default = true; }
     public bool   enable_local_discovery      { get; set; default = true; }
     public bool   enable_hole_punching        { get; set; default = true; }
+    public bool   enable_compact_contacts     { get; set; default = false; }
 
     private const string CREATE_TABLE_SETTINGS = """
       CREATE TABLE IF NOT EXISTS Settings (
-        id                   INTEGER PRIMARY KEY NOT NULL DEFAULT 0,
-        darktheme            INTEGER             NOT NULL,
-        animations           INTEGER             NOT NULL,
-        logging              INTEGER             NOT NULL,
-        urgencynotification  INTEGER             NOT NULL,
-        tray                 INTEGER             NOT NULL,
-        notify               INTEGER             NOT NULL,
-        infinitelog          INTEGER             NOT NULL,
-        sendtyping           INTEGER             NOT NULL,
-        daystolog            INTEGER             NOT NULL,
-        enableproxy          INTEGER             NOT NULL,
-        enablecustomproxy    INTEGER             NOT NULL,
-        customproxyhost      STRING              NOT NULL,
-        customproxyport      INTEGER             NOT NULL,
-        enableudp            INTEGER             NOT NULL,
-        enableipv6           INTEGER             NOT NULL,
-        enablelocaldiscovery INTEGER             NOT NULL,
-        enableholepunching   INTEGER             NOT NULL
+        id                   INTEGER PRIMARY KEY NOT NULL,
+        key                  TEXT                NOT NULL,
+        value                                    NOT NULL
       );
     """;
 
     private enum SettingsColumn {
       ID,
-      DARKTHEME,
-      ANIMATIONS,
-      LOGGING,
-      URGENCYNOTIFICATIONS,
-      TRAY,
-      NOTIFY,
-      INFINITELOG,
-      SENDTYPING,
-      DAYSTOLOG,
-      ENABLE_PROXY,
-      ENABLE_CUSTOM_PROXY,
-      CUSTOM_PROXY_HOST,
-      CUSTOM_PROXY_PORT,
-      ENABLE_UDP,
-      ENABLE_IPV6,
-      ENABLE_LOCAL_DISCOVERY,
-      ENABLE_HOLE_PUNCHING
+      KEY,
+      VALUE
     }
 
     private const string TABLE_ID = "$ID";
-    private const string TABLE_DARKTHEME = "$DARKTHEME";
-    private const string TABLE_ANIMATIONS = "$ANIMATIONS";
-    private const string TABLE_LOGGING = "$LOGGING";
-    private const string TABLE_URGENCYNOTIFICATIONS = "$URGENCYNOTIFICATIONS";
-    private const string TABLE_TRAY = "$TRAY";
-    private const string TABLE_NOTIFY = "$NOTIFY";
-    private const string TABLE_INFINITELOG = "$INFINITELOG";
-    private const string TABLE_SENDTYPING = "$SENDTYPING";
-    private const string TABLE_DAYSTOLOG = "$DAYSTOLOG";
-    private const string TABLE_ENABLE_PROXY = "$PROXY";
-    private const string TABLE_ENABLE_CUSTOM_PROXY = "$CUSTOMPROXY";
-    private const string TABLE_CUSTOM_PROXY_HOST = "$CUSTOMPROXYHOST";
-    private const string TABLE_CUSTOM_PROXY_PORT = "$CUSTOMPROXYPORT";
-    private const string TABLE_UDP = "$UDP";
-    private const string TABLE_IPV6 = "$IPV6";
-    private const string TABLE_LOCAL_DISCOVERY = "$LOCALDISCOVERY";
-    private const string TABLE_HOLE_PUNCHING = "$HOLEPUNCHING";
+    private const string TABLE_KEY = "$KEY";
+    private const string TABLE_VALUE = "$VALUE";
 
     private static string STATEMENT_INSERT_SETTINGS =
-      "INSERT OR REPLACE INTO Settings (id, darktheme, animations, logging, urgencynotification, tray, notify, infinitelog, sendtyping, daystolog, enableproxy, enablecustomproxy, customproxyhost, customproxyport, enableudp, enableipv6, enablelocaldiscovery, enableholepunching)"
-      + " VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);"
-          .printf(TABLE_ID,
-                  TABLE_DARKTHEME,
-                  TABLE_ANIMATIONS,
-                  TABLE_LOGGING,
-                  TABLE_URGENCYNOTIFICATIONS,
-                  TABLE_TRAY,
-                  TABLE_NOTIFY,
-                  TABLE_INFINITELOG,
-                  TABLE_SENDTYPING,
-                  TABLE_DAYSTOLOG,
-                  TABLE_ENABLE_PROXY,
-                  TABLE_ENABLE_CUSTOM_PROXY,
-                  TABLE_CUSTOM_PROXY_HOST,
-                  TABLE_CUSTOM_PROXY_PORT,
-                  TABLE_UDP,
-                  TABLE_IPV6,
-                  TABLE_LOCAL_DISCOVERY,
-                  TABLE_HOLE_PUNCHING);
+      "INSERT OR REPLACE INTO Settings (id, key, value)"
+      + " VALUES (%s, %s, %s);".printf(TABLE_ID, TABLE_KEY, TABLE_VALUE);
 
-    private static string STATEMENT_SELECT_SETTINGS = "SELECT * FROM Settings WHERE id = 0";
+    private static string STATEMENT_SELECT_SETTINGS = "SELECT * FROM Settings WHERE id = (%s)".printf(TABLE_ID);
 
     private IDatabaseStatement insertStatement;
     private IDatabaseStatement selectStatement;
 
     private ILogger logger;
-
-    private bool initialized = false;
 
     public SqliteSettingsDatabase(IDatabaseStatementFactory statementFactory, ILogger logger) throws DatabaseStatementError {
 
@@ -147,70 +83,68 @@ namespace Venom {
     }
 
     ~SqliteSettingsDatabase() {
-      save();
       logger.d("SqliteSettingsDatabase destroyed.");
     }
 
     public void load() {
-      if (initialized) {
-        save();
-      }
-      initialized = true;
-
+      logger.d("SqliteSettingsDatabase load.");
+      var props = get_class().list_properties();
+      selectStatement.reset();
       try {
-        if (selectStatement.step() == DatabaseResult.ROW) {
-          enable_dark_theme = selectStatement.column_bool(SettingsColumn.DARKTHEME);
-          enable_animations = selectStatement.column_bool(SettingsColumn.ANIMATIONS);
-          enable_logging = selectStatement.column_bool(SettingsColumn.LOGGING);
-          enable_urgency_notification = selectStatement.column_bool(SettingsColumn.URGENCYNOTIFICATIONS);
-          enable_tray = selectStatement.column_bool(SettingsColumn.TRAY);
-          enable_notify = selectStatement.column_bool(SettingsColumn.NOTIFY);
-          enable_infinite_log = selectStatement.column_bool(SettingsColumn.INFINITELOG);
-          enable_send_typing = selectStatement.column_bool(SettingsColumn.SENDTYPING);
-          days_to_log = selectStatement.column_int(SettingsColumn.DAYSTOLOG);
-          enable_proxy = selectStatement.column_bool(SettingsColumn.ENABLE_PROXY);
-          enable_custom_proxy = selectStatement.column_bool(SettingsColumn.ENABLE_CUSTOM_PROXY);
-          custom_proxy_host = selectStatement.column_text(SettingsColumn.CUSTOM_PROXY_HOST);
-          custom_proxy_port = selectStatement.column_int(SettingsColumn.CUSTOM_PROXY_PORT);
-          enable_udp = selectStatement.column_bool(SettingsColumn.ENABLE_UDP);
-          enable_ipv6 = selectStatement.column_bool(SettingsColumn.ENABLE_IPV6);
-          enable_local_discovery = selectStatement.column_bool(SettingsColumn.ENABLE_LOCAL_DISCOVERY);
-          enable_hole_punching = selectStatement.column_bool(SettingsColumn.ENABLE_HOLE_PUNCHING);
-        } else {
-          logger.i("No settings entry found.");
+        foreach (var p in props) {
+          var type = p.value_type;
+          selectStatement.bind_int(TABLE_ID, (int) p.name.hash());
+          if (selectStatement.step() == DatabaseResult.ROW) {
+            var val = new Value(type);
+            if (type == Type.BOOLEAN) {
+              val.set_boolean(selectStatement.column_bool(SettingsColumn.VALUE));
+            } else if (type == Type.INT) {
+              val.set_int(selectStatement.column_int(SettingsColumn.VALUE));
+            } else if (type == Type.STRING) {
+              val.set_string(selectStatement.column_text(SettingsColumn.VALUE));
+            } else {
+              logger.e(@"Unsupported type $(type.name()) for property $(p.name).");
+              selectStatement.reset();
+              continue;
+            }
+            set_property(p.name, val);
+          } else {
+            logger.i(@"No settings entry for property $(p.name) found.");
+          }
+          selectStatement.reset();
         }
       } catch (DatabaseStatementError e) {
         logger.e("Could not retrieve settings from database: " + e.message);
-      } finally {
-        selectStatement.reset();
       }
     }
 
     public void save() {
+      logger.d("SqliteSettingsDatabase save.");
+      var props = get_class().list_properties();
       try {
-        insertStatement.builder()
-            .bind_int( TABLE_ID, 0)
-            .bind_bool(TABLE_DARKTHEME, enable_dark_theme)
-            .bind_bool(TABLE_ANIMATIONS, enable_animations)
-            .bind_bool(TABLE_LOGGING, enable_logging)
-            .bind_bool(TABLE_URGENCYNOTIFICATIONS, enable_urgency_notification)
-            .bind_bool(TABLE_TRAY, enable_tray)
-            .bind_bool(TABLE_NOTIFY, enable_notify)
-            .bind_bool(TABLE_INFINITELOG, enable_infinite_log)
-            .bind_bool(TABLE_SENDTYPING, enable_send_typing)
-            .bind_int( TABLE_DAYSTOLOG, days_to_log)
-            .bind_bool(TABLE_ENABLE_PROXY, enable_proxy)
-            .bind_bool(TABLE_ENABLE_CUSTOM_PROXY, enable_custom_proxy)
-            .bind_text(TABLE_CUSTOM_PROXY_HOST, custom_proxy_host)
-            .bind_int(TABLE_CUSTOM_PROXY_PORT, custom_proxy_port)
-            .bind_bool(TABLE_UDP, enable_udp)
-            .bind_bool(TABLE_IPV6, enable_ipv6)
-            .bind_bool(TABLE_LOCAL_DISCOVERY, enable_local_discovery)
-            .bind_bool(TABLE_HOLE_PUNCHING, enable_hole_punching)
-            .step();
+        insertStatement.reset();
+        foreach (var p in props) {
+          var type = p.value_type;
+          insertStatement.bind_int(TABLE_ID, (int) p.name.hash());
+          insertStatement.bind_text(TABLE_KEY, p.name);
+          var val = new Value(type);
+          get_property(p.name, ref val);
+          if (type == Type.BOOLEAN) {
+            insertStatement.bind_bool(TABLE_VALUE, val.get_boolean());
+          } else if (type == Type.INT) {
+            insertStatement.bind_int(TABLE_VALUE, val.get_int());
+          } else if (type == Type.STRING) {
+            insertStatement.bind_text(TABLE_VALUE, val.get_string());
+          } else {
+            logger.e(@"Unsupported type $(type.name()) for property $(p.name).");
+            insertStatement.reset();
+            continue;
+          }
+          insertStatement.step();
+          insertStatement.reset();
+        }
       } catch (DatabaseStatementError e) {
-        logger.e("Could not insert settings into database: " + e.message);
-      } finally {
+        logger.e("Could not retrieve settings from database: " + e.message);
         insertStatement.reset();
       }
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -85,6 +85,7 @@ venom_source = files(
 			'view/ConferenceInviteEntry.vala',
 			'view/ConferenceWindow.vala',
 			'view/ContactListEntry.vala',
+			'view/ContactListEntryCompact.vala',
 			'view/ContactListRequestEntry.vala',
 			'view/ContactListWidget.vala',
 			'view/ContextStyleBinding.vala',

--- a/src/ui/contact_list_entry_compact.ui
+++ b/src/ui/contact_list_entry_compact.ui
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 
+
+Copyright (C) 2013-2018 Venom authors and contributors
+
+This file is part of Venom.
+
+Venom is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Venom is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Venom.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<interface domain="venom">
+  <requires lib="gtk+" version="3.20"/>
+  <!-- interface-license-type gplv3 -->
+  <!-- interface-name Venom -->
+  <!-- interface-copyright 2013-2018 Venom authors and contributors -->
+  <template class="VenomContactListEntryCompact" parent="GtkListBoxRow">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">6</property>
+        <property name="margin_right">6</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkImage" id="contact_image">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="pixel_size">22</property>
+            <property name="icon_name">friend-symbolic</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage" id="status_image">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="pixel_size">22</property>
+            <property name="icon_name">online-symbolic</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="contact_name">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label">contact_name</property>
+            <property name="ellipsize">end</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="contact_status">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label">contact_status</property>
+            <property name="ellipsize">end</property>
+            <property name="xalign">0</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/ui/settings_widget.ui
+++ b/src/ui/settings_widget.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1
+<!-- Generated with glade 3.22.1 
 
 Copyright (C) 2013-2018 Venom authors and contributors
 
@@ -538,6 +538,76 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                                             </child>
                                             <child>
                                               <object class="GtkSwitch" id="enable_tray_switch">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="valign">center</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack_type">end</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="border_width">6</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkBox">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="valign">center</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="label" translatable="yes">Small contacts</property>
+                                                    <property name="xalign">0</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="label" translatable="yes">&lt;small&gt;Show contacts in a more compact format&lt;/small&gt;</property>
+                                                    <property name="use_markup">True</property>
+                                                    <property name="xalign">0</property>
+                                                    <style>
+                                                      <class name="dim-label"/>
+                                                    </style>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="enable_compact_contacts">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="valign">center</property>

--- a/src/ui/venom.gresource.xml
+++ b/src/ui/venom.gresource.xml
@@ -26,6 +26,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
     <file compressed="true" preprocess="xml-stripblanks">conference_invite_entry.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">conference_window.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">contact_list_entry.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">contact_list_entry_compact.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">contact_list_request_entry.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">contact_list_widget.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">conversation_window.ui</file>

--- a/src/view/ApplicationWindow.vala
+++ b/src/view/ApplicationWindow.vala
@@ -211,7 +211,7 @@ namespace Venom {
         logger.f("Could not set icon from theme: " + e.message);
       }
 
-      var contact_list = new ContactListWidget(logger, this, contacts, friend_requests, conference_invites, this, user_info);
+      var contact_list = new ContactListWidget(logger, this, contacts, friend_requests, conference_invites, this, user_info, settings_database);
       contact_list_box.pack_start(contact_list, true, true);
       contact_list_view_model = contact_list.get_model();
       content_paned.bind_property("position", user_info_box, "width-request", BindingFlags.SYNC_CREATE,

--- a/src/view/ContactListEntryCompact.vala
+++ b/src/view/ContactListEntryCompact.vala
@@ -1,5 +1,5 @@
 /*
- *    ContactListEntry.vala
+ *    ContactListEntryCompact.vala
  *
  *    Copyright (C) 2018 Venom authors and contributors
  *
@@ -20,8 +20,8 @@
  */
 
 namespace Venom {
-  [GtkTemplate(ui = "/chat/tox/venom/ui/contact_list_entry.ui")]
-  public class ContactListEntry : Gtk.ListBoxRow {
+  [GtkTemplate(ui = "/chat/tox/venom/ui/contact_list_entry_compact.ui")]
+  public class ContactListEntryCompact : Gtk.ListBoxRow {
     [GtkChild] private Gtk.Label contact_name;
     [GtkChild] private Gtk.Label contact_status;
     [GtkChild] private Gtk.Image contact_image;
@@ -31,10 +31,10 @@ namespace Venom {
     private ContactListEntryViewModel view_model;
     private ContextStyleBinding attention_binding;
 
-    public ContactListEntry(ILogger logger, IContact contact) {
-      logger.d("ContactListEntry created.");
+    public ContactListEntryCompact(ILogger logger, IContact contact) {
+      logger.d("ContactListEntryCompact created.");
       this.logger = logger;
-      this.view_model = new ContactListEntryViewModel(logger, contact, false);
+      this.view_model = new ContactListEntryViewModel(logger, contact, true);
       this.attention_binding = new ContextStyleBinding(status_image, "highlight");
 
       view_model.bind_property("contact-name", contact_name, "label", GLib.BindingFlags.SYNC_CREATE);
@@ -45,8 +45,8 @@ namespace Venom {
       view_model.bind_property("contact-requires-attention", attention_binding, "enable", GLib.BindingFlags.SYNC_CREATE);
     }
 
-    ~ContactListEntry() {
-      logger.d("ContactListEntry destroyed.");
+    ~ContactListEntryCompact() {
+      logger.d("ContactListEntryCompact destroyed.");
     }
   }
 }

--- a/src/view/SettingsWidget.vala
+++ b/src/view/SettingsWidget.vala
@@ -55,6 +55,7 @@ namespace Venom {
     [GtkChild] private Gtk.Switch enable_ipv6;
     [GtkChild] private Gtk.Switch enable_local_discovery;
     [GtkChild] private Gtk.Switch enable_hole_punching;
+    [GtkChild] private Gtk.Switch enable_compact_contacts;
 
     private ObservableList dht_nodes;
     private ObservableListModel list_model;
@@ -90,6 +91,7 @@ namespace Venom {
       settingsDatabase.bind_property("enable-ipv6",         enable_ipv6,               "active",  BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
       settingsDatabase.bind_property("enable-local-discovery", enable_local_discovery, "active",  BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
       settingsDatabase.bind_property("enable-hole-punching", enable_hole_punching,     "active",  BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
+      settingsDatabase.bind_property("enable-compact-contacts", enable_compact_contacts, "active",  BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
       var dhtNodeFactory = new DhtNodeFactory();
       dht_nodes = new ObservableList();

--- a/src/viewmodel/ContactListEntryViewModel.vala
+++ b/src/viewmodel/ContactListEntryViewModel.vala
@@ -23,6 +23,7 @@ namespace Venom {
   public class ContactListEntryViewModel : GLib.Object {
     private ILogger logger;
     private IContact contact;
+    private bool compact;
 
     public string contact_name { get; set; }
     public string contact_status { get; set; }
@@ -31,10 +32,11 @@ namespace Venom {
     public string contact_status_tooltip { get; set; }
     public bool contact_requires_attention { get; set; }
 
-    public ContactListEntryViewModel(ILogger logger, IContact contact) {
+    public ContactListEntryViewModel(ILogger logger, IContact contact, bool compact) {
       logger.d("ContactListEntryViewModel created.");
       this.logger = logger;
       this.contact = contact;
+      this.compact = compact;
 
       contact.changed.connect(update_contact);
       update_contact();
@@ -51,7 +53,8 @@ namespace Venom {
 
       var pixbuf = contact.get_image();
       if (pixbuf != null) {
-        contact_image = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
+        var size = compact ? 22 : 44;
+        contact_image = round_corners(pixbuf.scale_simple(size, size, Gdk.InterpType.BILINEAR));
       }
 
       if (contact_requires_attention) {


### PR DESCRIPTION
* Add a compact version of `ContactListEntry`
* Rework settings database to automatically store all
  class properties similiar to a hashtable.
  This should allow simple adding of new options without
  breaking the database each time and should be easier
  to adapt for new settings.

closes #125