### PR TITLE
VENOM-388: Fix user image getting reset when hitting apply

### DIFF
--- a/src/core/UserInfo.vala
+++ b/src/core/UserInfo.vala
@@ -35,13 +35,14 @@ namespace Venom {
   public class Avatar : GLib.Object {
     public Gdk.Pixbuf pixbuf { get; set; }
     public GLib.Bytes hash { get; set; }
-    public Avatar() {
-      reset();
+
+    construct {
+      hash = new GLib.Bytes(new uint8[] {});
     }
 
-    public void reset() {
-      pixbuf = pixbuf_from_resource(R.icons.default_contact, 128);
-      hash = new GLib.Bytes(new uint8[] {});
+    public void set_from_pixbuf(ILogger logger, Gdk.Pixbuf pixbuf) {
+      this.hash = new GLib.Bytes(new uint8[] {});
+      this.pixbuf = pixbuf;
     }
 
     public void set_from_data(ILogger logger, uint8[] data, Gdk.Pixbuf? pixbuf = null) throws Error {
@@ -58,7 +59,7 @@ namespace Venom {
         }
         unowned Gdk.Pixbuf tmp = loader.get_pixbuf();
         if (tmp != null) {
-          this.pixbuf = tmp.scale_simple(128, 128, Gdk.InterpType.BILINEAR);
+          this.pixbuf = tmp.scale_simple(120, 120, Gdk.InterpType.BILINEAR);
         }
       }
     }

--- a/src/ui/user_info_widget.ui
+++ b/src/ui/user_info_widget.ui
@@ -173,12 +173,9 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                   <object class="GtkImage" id="avatar">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="pixel_size">128</property>
-                    <property name="icon_name">friend-symbolic</property>
+                    <property name="stock">gtk-missing-image</property>
+                    <property name="pixel_size">120</property>
                     <property name="icon_size">0</property>
-                    <style>
-                      <class name="avatar"/>
-                    </style>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
* Adapted the listener to load an identicon if there is no user avatar
* Add an enum to differentiate between set/reset/no change in
  ViewModel
* Set size of own images to 120x120px (default identicon size)
* Removed `avatar` style class as it's not as pretty as it should be

fixes #388