### PR TITLE
VENOM-394: Catch toxcore startup errors

### DIFF
--- a/src/core/Interfaces.vala
+++ b/src/core/Interfaces.vala
@@ -39,6 +39,7 @@ namespace Venom {
     public abstract void w(string message);
     public abstract void e(string message);
     public abstract void f(string message);
+    public abstract string get_log();
     public abstract void attach_to_glib();
   }
 

--- a/src/core/Logger.vala
+++ b/src/core/Logger.vala
@@ -65,8 +65,13 @@ namespace Venom {
 
   public class Logger : ILogger, Object {
     public static LogLevel displayed_level { get; set; default = LogLevel.WARNING; }
+    private StringBuilder log_builder;
+    public string get_log() {
+      return log_builder.str;
+    }
 
     public Logger() {
+      log_builder = new StringBuilder();
       d("Logger created.");
     }
 
@@ -130,10 +135,13 @@ namespace Venom {
       GLib.Log.set_handler("Json", LogLevelFlags.LEVEL_MASK, glib_log_function);
     }
 
-    public static void log(LogLevel level, string message) {
+    public void log(LogLevel level, string message) {
+      log_builder.append("%s\n".printf(message));
+
       if (level < displayed_level) {
         return;
       }
+
       unowned FileStream s = level < LogLevel.ERROR ? stdout : stderr;
       s.printf("[%s] %s\n", level.to_string(), message);
     }

--- a/src/core/WidgetFactory.vala
+++ b/src/core/WidgetFactory.vala
@@ -1,7 +1,7 @@
 /*
  *    WidgetFactory.vala
  *
- *    Copyright (C) 2013-2018  Venom authors and contributors
+ *    Copyright (C) 2013-2018 Venom authors and contributors
  *
  *    This file is part of Venom.
  *
@@ -21,21 +21,23 @@
 
 namespace Venom.Factory {
   public interface IWidgetFactory : Object {
-    public abstract ApplicationWindow createApplicationWindow(Gtk.Application application,
-                                                              IDhtNodeDatabase node_database, ISettingsDatabase settings_database, IContactDatabase contact_database);
+    public abstract ApplicationWindow createApplicationWindow(Gtk.Application application, ToxSession session, IDhtNodeDatabase node_database, ISettingsDatabase settings_database, IContactDatabase contact_database);
     public abstract ILogger createLogger();
     public abstract Gtk.Dialog createAboutDialog();
     public abstract IDatabaseFactory createDatabaseFactory();
-    public abstract Gtk.Widget createSettingsWidget(ApplicationWindow app_window, ISettingsDatabase database, IDhtNodeDatabase nodeDatabase);
+    public abstract SettingsWidget createSettingsWidget(ApplicationWindow? app_window, ISettingsDatabase database, IDhtNodeDatabase nodeDatabase);
   }
 
   public class WidgetFactory : IWidgetFactory, Object {
     private ILogger logger;
     private Gtk.Dialog about_dialog;
+    private ApplicationWindow app_window;
 
-    public ApplicationWindow createApplicationWindow(Gtk.Application application,
-                                                     IDhtNodeDatabase node_database, ISettingsDatabase settings_database, IContactDatabase contact_database) {
-      return new ApplicationWindow(application, this, node_database, settings_database, contact_database);
+    public ApplicationWindow createApplicationWindow(Gtk.Application application, ToxSession session, IDhtNodeDatabase node_database, ISettingsDatabase settings_database, IContactDatabase contact_database) {
+      if (app_window == null) {
+        app_window = new ApplicationWindow(application, this, session, node_database, settings_database, contact_database);
+      }
+      return app_window;
     }
 
     public ILogger createLogger() {
@@ -53,12 +55,12 @@ namespace Venom.Factory {
       if (about_dialog == null) {
         about_dialog = new AboutDialog(logger);
         about_dialog.modal = true;
-        about_dialog.unmap.connect(() => { about_dialog = null; });
+        about_dialog.destroy.connect(() => { about_dialog = null; });
       }
       return about_dialog;
     }
 
-    public Gtk.Widget createSettingsWidget(ApplicationWindow app_window, ISettingsDatabase settingsDatabase, IDhtNodeDatabase nodeDatabase) {
+    public SettingsWidget createSettingsWidget(ApplicationWindow? app_window, ISettingsDatabase settingsDatabase, IDhtNodeDatabase nodeDatabase) {
       return new SettingsWidget(createLogger(), app_window, settingsDatabase, nodeDatabase);
     }
   }

--- a/src/meson.build
+++ b/src/meson.build
@@ -91,6 +91,7 @@ venom_source = files(
 			'view/ContextStyleBinding.vala',
 			'view/ConversationWindow.vala',
 			'view/CreateGroupchatWidget.vala',
+			'view/ErrorWidget.vala',
 			'view/FileTransferEntry.vala',
 			'view/FileTransferEntryInline.vala',
 			'view/FileTransferWidget.vala',

--- a/src/testing/mocks/MockLogger.vala
+++ b/src/testing/mocks/MockLogger.vala
@@ -30,5 +30,6 @@ namespace Mock {
     public void e(string message) { mock().actual_call(this, "e", args().string(message).create()); }
     public void f(string message) { mock().actual_call(this, "f", args().string(message).create()); }
     public void attach_to_glib() { mock().actual_call(this, "attach_to_glib"); }
+    public string get_log() { return mock().actual_call(this, "get_log").get_string();}
   }
 }

--- a/src/ui/error_widget.ui
+++ b/src/ui/error_widget.ui
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 
+
+Copyright (C) 2013-2018 Venom authors and contributors
+
+This file is part of Venom.
+
+Venom is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Venom is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Venom.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<interface domain="venom">
+  <requires lib="gtk+" version="3.20"/>
+  <!-- interface-license-type gplv3 -->
+  <!-- interface-name Venom -->
+  <!-- interface-copyright 2013-2018 Venom authors and contributors -->
+  <template class="VenomErrorWidget" parent="GtkBox">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">6</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+    <child>
+      <object class="GtkStackSwitcher">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">center</property>
+        <property name="stack">stack</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkStack" id="stack">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="transition_type">crossfade</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="message">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">message</property>
+                <property name="selectable">True</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="pixel_size">96</property>
+                    <property name="icon_name">face-sick-symbolic</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Oh no! Something broke!</property>
+                    <attributes>
+                      <attribute name="size" value="14000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Please check your settings and retry</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">info</property>
+            <property name="title" translatable="yes">Info</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkButton" id="retry">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <property name="halign">end</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">view-refresh-symbolic</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Retry</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <style>
+          <class name="suggested-action"/>
+        </style>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="pack_type">end</property>
+        <property name="position">3</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/src/ui/venom.gresource.xml
+++ b/src/ui/venom.gresource.xml
@@ -30,6 +30,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
     <file compressed="true" preprocess="xml-stripblanks">contact_list_widget.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">conversation_window.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">create_groupchat_widget.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">error_widget.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">file_transfer_entry.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">file_transfer_entry_inline.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">file_transfer_widget.ui</file>

--- a/src/view/ApplicationWindow.vala
+++ b/src/view/ApplicationWindow.vala
@@ -44,7 +44,7 @@ namespace Venom {
     [GtkChild] public Gtk.Box header_start;
     [GtkChild] public Gtk.Box header_end;
 
-    private Factory.IWidgetFactory widget_factory;
+    private unowned Factory.IWidgetFactory widget_factory;
     private ILogger logger;
     private ISettingsDatabase settings_database;
     private IContactDatabase contact_database;
@@ -66,8 +66,8 @@ namespace Venom {
     private GLib.HashTable<IContact, ObservableList> conversations;
     private UserInfo user_info;
 
-    public ApplicationWindow(Gtk.Application application, Factory.IWidgetFactory widget_factory, IDhtNodeDatabase node_database,
-                             ISettingsDatabase settings_database, IContactDatabase contact_database) {
+    public ApplicationWindow(Gtk.Application application, Factory.IWidgetFactory widget_factory, ToxSession session,
+                             IDhtNodeDatabase node_database, ISettingsDatabase settings_database, IContactDatabase contact_database) {
       Object(application: application);
 
       conversations = new GLib.HashTable<IContact, ObservableList>(null, null);
@@ -113,16 +113,10 @@ namespace Venom {
       init_window_state();
       init_widgets();
 
-      try {
-        var session_io = new ToxSessionIOImpl(logger);
-        session = new ToxSessionImpl(session_io, node_database, settings_database, logger);
-        session_listener.attach_to_session(session);
-        friend_listener.attach_to_session(session);
-        conference_listener.attach_to_session(session);
-        filetransfer_listener.attach_to_session(session);
-      } catch (Error e) {
-        logger.e("Could not create tox instance: " + e.message);
-      }
+      session_listener.attach_to_session(session);
+      friend_listener.attach_to_session(session);
+      conference_listener.attach_to_session(session);
+      filetransfer_listener.attach_to_session(session);
 
       status_icon.activate.connect(on_status_icon_activate);
       delete_event.connect(on_delete_event);

--- a/src/view/ErrorWidget.vala
+++ b/src/view/ErrorWidget.vala
@@ -1,0 +1,42 @@
+/*
+ *    ErrorWidget.vala
+ *
+ *    Copyright (C) 2018 Venom authors and contributors
+ *
+ *    This file is part of Venom.
+ *
+ *    Venom is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Venom is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with Venom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Venom {
+  [GtkTemplate(ui = "/chat/tox/venom/ui/error_widget.ui")]
+  public class ErrorWidget : Gtk.Box {
+    [GtkChild] private Gtk.Stack stack;
+    [GtkChild] private Gtk.Label message;
+    [GtkChild] private Gtk.Button retry;
+
+    public signal void on_retry();
+
+    public ErrorWidget(Gtk.ApplicationWindow application_window, string error_message) {
+      message.label = error_message;
+      retry.clicked.connect(() => { on_retry(); });
+    }
+
+    public void add_page(Gtk.Widget widget, string name, string title) {
+      var scrolled_window = new Gtk.ScrolledWindow(null, null);
+      scrolled_window.add(widget);
+      stack.add_titled(scrolled_window, name, title);
+    }
+  }
+}


### PR DESCRIPTION
* Add an `error_widget` to display to the user on `toxcore` startup errors
* Keep all logged messages in a `StringBuffer`

Showcase: https://streamable.com/a7p4h