### PR TITLE
VENOM-401: UI improvements

### DIFF
--- a/data/chat.tox.venom.desktop.in
+++ b/data/chat.tox.venom.desktop.in
@@ -10,3 +10,8 @@ Categories=InstantMessaging;Network;
 DBusActivatable=true
 StartupNotify=true
 X-GNOME-UsesNotifications=true
+Actions=preferences;
+
+[Desktop Action preferences]
+Name=Preferences
+Exec=venom --preferences

--- a/src/core/Identicon.vala
+++ b/src/core/Identicon.vala
@@ -28,7 +28,7 @@ namespace Venom {
     private Cairo.Surface surface;
 
     public static Gdk.Pixbuf generate_pixbuf(uint8[] public_key, int size = 120) {
-      var identicon = new Identicon(public_key);
+      var identicon = new Identicon(public_key, size);
       identicon.draw();
       return identicon.get_pixbuf();
     }

--- a/src/core/Logger.vala
+++ b/src/core/Logger.vala
@@ -38,6 +38,12 @@ namespace Venom {
     public const string FATAL = TermColor.MAGENTA;
   }
 
+  namespace PangoHelper {
+    public static string insert_span(string attributes, string content) {
+      return @"<span $attributes>$content</span>";
+    }
+  }
+
   public enum LogLevel {
     DEBUG,
     INFO,
@@ -57,6 +63,23 @@ namespace Venom {
           return TermColor.ERROR + "ERROR" + TermColor.RESET;
         case FATAL:
           return TermColor.FATAL + "FATAL" + TermColor.RESET;
+        default:
+          assert_not_reached();
+      }
+    }
+
+    public string to_markup() {
+      switch(this) {
+        case DEBUG:
+          return "DEBUG";
+        case INFO:
+          return PangoHelper.insert_span("foreground=\"green\"", "INFO ");
+        case WARNING:
+          return PangoHelper.insert_span("foreground=\"yellow\"", "WARN ");
+        case ERROR:
+          return PangoHelper.insert_span("foreground=\"red\"", "ERROR");
+        case FATAL:
+          return PangoHelper.insert_span("foreground=\"magenta\"", "FATAL");
         default:
           assert_not_reached();
       }
@@ -136,7 +159,7 @@ namespace Venom {
     }
 
     public void log(LogLevel level, string message) {
-      log_builder.append("%s\n".printf(message));
+      log_builder.append("[%s] %s\n".printf(level.to_markup(), message));
 
       if (level < displayed_level) {
         return;

--- a/src/core/Message.vala
+++ b/src/core/Message.vala
@@ -35,6 +35,7 @@ namespace Venom {
     public abstract bool received                      { get; set; }
 
     public abstract string get_sender_plain();
+    public abstract string get_sender_full();
     public abstract string get_sender_id();
     public abstract string get_conversation_id();
     public abstract string get_message_plain();
@@ -80,6 +81,10 @@ namespace Venom {
       } else {
         return from.get_name_string();
       }
+    }
+
+    public string get_sender_full() {
+      return get_sender_plain();
     }
 
     public string get_sender_id() {

--- a/src/core/NotificationListener.vala
+++ b/src/core/NotificationListener.vala
@@ -83,10 +83,15 @@ namespace Venom {
         return;
       }
 
-      var notification = new Notification(_("New message from %s").printf(message.get_sender_plain()));
+      var title = _("New message from %s").printf(message.get_sender_full());
+      var contact_id = new GLib.Variant.string(message.get_conversation_id());
+
+      var notification = new Notification(title);
       notification.set_body(message.get_message_plain());
       notification.set_icon(scale_icon(message.get_sender_image()));
-      notification.set_default_action_and_target_value("app.show-contact", new GLib.Variant.string(message.get_conversation_id()));
+      notification.set_default_action_and_target_value("app.show-contact", contact_id);
+      notification.add_button_with_target_value(_("Show details"), "app.show-contact-info", contact_id);
+      notification.add_button_with_target_value(_("Mute conversation"), "app.mute-contact", contact_id);
       app.send_notification(message_id, notification);
 
       play_sound("message-new-instant");

--- a/src/tox/ConferenceMessage.vala
+++ b/src/tox/ConferenceMessage.vala
@@ -27,13 +27,17 @@ namespace Venom {
     public bool is_action                     { get; set; }
     public bool received                      { get; set; }
 
-    public uint32 conference_number           { get; protected set; }
     public string message                     { get; protected set; }
     public string peer_name                   { get; protected set; }
     public string peer_key                    { get; protected set; }
 
-    private ConferenceMessage(uint32 conference_number, MessageDirection direction, string message, GLib.DateTime timestamp) {
-      this.conference_number = conference_number;
+    public unowned IContact from              { get; protected set; }
+    public unowned IContact to                { get; protected set; }
+
+    private unowned IContact conference;
+
+    private ConferenceMessage(IContact conference, MessageDirection direction, string message, GLib.DateTime timestamp) {
+      this.conference = conference;
       this.message_direction = direction;
       this.message = message;
       this.timestamp = timestamp;
@@ -41,12 +45,12 @@ namespace Venom {
       this.is_action = false;
     }
 
-    public ConferenceMessage.outgoing(uint32 conference_number, string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
-      this(conference_number, MessageDirection.OUTGOING, message, timestamp);
+    public ConferenceMessage.outgoing(IContact conference, string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
+      this(conference, MessageDirection.OUTGOING, message, timestamp);
     }
 
-    public ConferenceMessage.incoming(uint32 conference_number, string peer_key, string peer_name, string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
-      this(conference_number, MessageDirection.INCOMING, message, timestamp);
+    public ConferenceMessage.incoming(IContact conference, string peer_key, string peer_name, string message, GLib.DateTime timestamp = new GLib.DateTime.now_local()) {
+      this(conference, MessageDirection.INCOMING, message, timestamp);
       this.peer_key = peer_key;
       this.peer_name = peer_name;
     }
@@ -59,8 +63,12 @@ namespace Venom {
       }
     }
 
+    public string get_sender_full() {
+      return _("%s in %s").printf(get_sender_plain(), conference.get_name_string());
+    }
+
     public string get_conversation_id() {
-      return @"tox.conference.$conference_number";
+      return conference.get_id();
     }
 
     public string get_sender_id() {

--- a/src/tox/ToxAdapterConferenceListener.vala
+++ b/src/tox/ToxAdapterConferenceListener.vala
@@ -187,7 +187,7 @@ namespace Venom {
       var contact = conferences.@get(conference_number) as Conference;
       var conversation = conversations.@get(contact);
       var peer = contact.get_peers().@get(peer_number);
-      var msg = new ConferenceMessage.incoming(conference_number, peer.peer_key, peer.peer_name, message);
+      var msg = new ConferenceMessage.incoming(contact, peer.peer_key, peer.peer_name, message);
       notification_listener.on_unread_message(msg, contact);
       contact.unread_messages++;
       contact.changed();
@@ -198,7 +198,7 @@ namespace Venom {
       logger.d("on_conference_message_sent");
       var contact = conferences.@get(conference_number) as Conference;
       var conversation = conversations.@get(contact);
-      var msg = new ConferenceMessage.outgoing(conference_number, message);
+      var msg = new ConferenceMessage.outgoing(contact, message);
       msg.received = true;
       conversation.append(msg);
     }

--- a/src/ui/conference_window.ui
+++ b/src/ui/conference_window.ui
@@ -137,7 +137,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
     <property name="tooltip_text" translatable="yes">Show details</property>
     <property name="action_name">win.conference-info</property>
     <child>
-      <object class="GtkImage">
+      <object class="GtkImage" id="user_image">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="pixel_size">22</property>

--- a/src/ui/contact_list_widget.ui
+++ b/src/ui/contact_list_widget.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1
+<!-- Generated with glade 3.22.1 
 
 Copyright (C) 2013-2018 Venom authors and contributors
 
@@ -403,7 +403,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Open settings</property>
+            <property name="tooltip_text" translatable="yes">Open preferences</property>
             <property name="action_name">app.preferences</property>
             <property name="relief">none</property>
             <child>

--- a/src/ui/create_groupchat_widget.ui
+++ b/src/ui/create_groupchat_widget.ui
@@ -340,6 +340,111 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkButton" id="accept_all">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">object-select-symbolic</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Accept all</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="reject_all">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">user-trash-symbolic</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Reject all</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="destructive-action"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="name">page1</property>

--- a/src/ui/friend_info_widget.ui
+++ b/src/ui/friend_info_widget.ui
@@ -545,19 +545,49 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="border_width">6</property>
-                        <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Public key:</property>
-                            <property name="use_underline">True</property>
-                            <property name="ellipsize">end</property>
-                            <property name="xalign">0</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Public key:</property>
+                                <property name="use_underline">True</property>
+                                <property name="ellipsize">end</property>
+                                <property name="xalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="tox_id">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label">##################</property>
+                                <property name="selectable">True</property>
+                                <property name="ellipsize">end</property>
+                                <property name="xalign">0</property>
+                                <style>
+                                  <class name="monospace"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -566,20 +596,15 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="tox_id">
+                          <object class="GtkImage" id="tox_identicon">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label">##################</property>
-                            <property name="selectable">True</property>
-                            <property name="ellipsize">end</property>
-                            <property name="xalign">0</property>
-                            <style>
-                              <class name="monospace"/>
-                            </style>
+                            <property name="stock">gtk-missing-image</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
+                            <property name="pack_type">end</property>
                             <property name="position">1</property>
                           </packing>
                         </child>

--- a/src/ui/message_widget.ui
+++ b/src/ui/message_widget.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1
+<!-- Generated with glade 3.22.1 
 
 Copyright (C) 2013-2018 Venom authors and contributors
 
@@ -37,7 +37,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="valign">start</property>
-            <property name="pixel_size">44</property>
+            <property name="pixel_size">20</property>
             <property name="icon_name">user-info-symbolic</property>
             <property name="icon_size">6</property>
             <style>
@@ -59,6 +59,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="sender">
                     <property name="visible">True</property>
@@ -75,67 +76,32 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRevealer" id="additional_info">
+                  <object class="GtkLabel" id="timestamp">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">6</property>
-                    <property name="transition_type">slide-right</property>
-                    <property name="transition_duration">125</property>
-                    <child>
-                      <object class="GtkLabel" id="timestamp">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">timestamp</property>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
-                      </object>
-                    </child>
+                    <property name="label">timestamp</property>
+                    <property name="ellipsize">start</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="pack_type">end</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
+                  <object class="GtkImage" id="sent">
                     <property name="can_focus">False</property>
-                    <property name="margin_left">6</property>
-                    <child>
-                      <object class="GtkImage" id="sent">
-                        <property name="can_focus">False</property>
-                        <property name="no_show_all">True</property>
-                        <property name="tooltip_text" translatable="yes">Message sent ✓</property>
-                        <property name="icon_name">object-select-symbolic</property>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkImage" id="received">
-                        <property name="can_focus">False</property>
-                        <property name="no_show_all">True</property>
-                        <property name="tooltip_text" translatable="yes">Message received ✓</property>
-                        <property name="icon_name">object-select-symbolic</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="no_show_all">True</property>
+                    <property name="icon_name">emblem-ok-symbolic</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="pack_type">end</property>
                     <property name="position">2</property>
                   </packing>
                 </child>

--- a/src/ui/peer_entry.ui
+++ b/src/ui/peer_entry.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1
+<!-- Generated with glade 3.22.1 
 
 Copyright (C) 2013-2018 Venom authors and contributors
 
@@ -38,7 +38,6 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="icon_name">friend-symbolic</property>
-            <property name="icon_size">5</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -62,7 +61,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label">peer_name</property>
-                    <property name="xalign">0</property>
+                    <property name="selectable">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -108,6 +107,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label">peer_key</property>
+                <property name="selectable">True</property>
                 <property name="xalign">0</property>
                 <style>
                   <class name="monospace"/>

--- a/src/ui/welcome_widget.ui
+++ b/src/ui/welcome_widget.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1
+<!-- Generated with glade 3.22.1 
 
 Copyright (C) 2013-2018 Venom authors and contributors
 
@@ -46,7 +46,6 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="icon_size">6</property>
             <style>
               <class name="welcome-highlight"/>
-              <class name="dim-label"/>
             </style>
           </object>
           <packing>
@@ -56,14 +55,11 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
           </packing>
         </child>
         <child>
-          <object class="GtkLabel">
+          <object class="GtkLabel" id="title">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">&lt;big&gt;A new kind of instant messaging&lt;/big&gt;</property>
+            <property name="label">&lt;big&gt;Some title&lt;/big&gt;</property>
             <property name="use_markup">True</property>
-            <style>
-              <class name="dim-label"/>
-            </style>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -72,15 +68,13 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
           </packing>
         </child>
         <child>
-          <object class="GtkLabel">
+          <object class="GtkLabel" id="content">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Chat with your friends and family without anyone else listening in.</property>
+            <property name="label">Some content</property>
+            <property name="use_markup">True</property>
             <property name="justify">center</property>
             <property name="wrap">True</property>
-            <style>
-              <class name="dim-label"/>
-            </style>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -88,6 +82,9 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="position">2</property>
           </packing>
         </child>
+        <style>
+          <class name="dim-label"/>
+        </style>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -106,7 +103,6 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-            <property name="halign">center</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
@@ -153,7 +149,6 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-            <property name="halign">center</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>

--- a/src/view/AddContactWidget.vala
+++ b/src/view/AddContactWidget.vala
@@ -66,6 +66,10 @@ namespace Venom {
 
       contact_id.icon_release.connect(view_model.on_paste_clipboard);
       send.clicked.connect(view_model.on_send);
+
+      if (view_model.new_friend_request) {
+        stack.set_visible_child(friend_request_item);
+      }
     }
 
     ~AddContactWidget() {

--- a/src/view/ConferenceInviteEntry.vala
+++ b/src/view/ConferenceInviteEntry.vala
@@ -43,7 +43,7 @@ namespace Venom {
 
       var pixbuf = sender.get_image();
       if (pixbuf != null) {
-        contact_image.pixbuf = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
+        contact_image.pixbuf = round_corners(pixbuf.scale_simple(40, 40, Gdk.InterpType.BILINEAR));
       }
       contact_description.label = _("Invite from %s").printf(sender.get_name_string());
       contact_time.label = TimeStamp.get_pretty_timestamp(invite.timestamp);

--- a/src/view/ConferenceWindow.vala
+++ b/src/view/ConferenceWindow.vala
@@ -22,6 +22,7 @@
 namespace Venom {
   [GtkTemplate(ui = "/chat/tox/venom/ui/conference_window.ui")]
   public class ConferenceWindow : Gtk.Box {
+    [GtkChild] private Gtk.Image user_image;
     [GtkChild] private Gtk.TextView text_view;
     [GtkChild] private Gtk.ListBox message_list;
     [GtkChild] private Gtk.ScrolledWindow scrolled_window;
@@ -33,7 +34,7 @@ namespace Venom {
 
     private const GLib.ActionEntry win_entries[] =
     {
-      { "conference-info",  on_conference_info,  null, null, null },
+      { "conference-info", on_conference_info,  null, null, null },
       { "insert-smiley", on_insert_smiley, null, null, null }
     };
 
@@ -112,6 +113,11 @@ namespace Venom {
         contact.clear_attention();
         contact.changed();
         return;
+      }
+
+      var pixbuf = contact.get_image();
+      if (pixbuf != null) {
+        user_image.pixbuf = round_corners(pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR));
       }
 
       this.peers_list = new ObservableList();

--- a/src/view/CreateGroupchatWidget.vala
+++ b/src/view/CreateGroupchatWidget.vala
@@ -33,6 +33,9 @@ namespace Venom {
     [GtkChild] private Gtk.Stack stack;
     [GtkChild] private Gtk.Widget custom_title;
 
+    [GtkChild] private Gtk.Button accept_all;
+    [GtkChild] private Gtk.Button reject_all;
+
     private ILogger logger;
     private CreateGroupchatViewModel view_model;
     private ContainerChildBooleanBinding stack_binding;
@@ -40,7 +43,7 @@ namespace Venom {
     public CreateGroupchatWidget(ILogger logger, ApplicationWindow app_window, ObservableList conference_invites_model, CreateGroupchatWidgetListener listener, ConferenceInviteEntryListener entry_listener) {
       logger.d("CreateGroupChatWidget created.");
       this.logger = logger;
-      this.view_model = new CreateGroupchatViewModel(logger, conference_invites_model, listener);
+      this.view_model = new CreateGroupchatViewModel(logger, conference_invites_model, listener, entry_listener);
       this.stack_binding = new ContainerChildBooleanBinding(stack, conference_invite_item, "needs-attention");
 
       app_window.reset_header_bar();
@@ -56,8 +59,16 @@ namespace Venom {
       view_model.bind_property("title-error-visible", title_error_content, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
       view_model.bind_property("new-conference-invite", stack_binding, "active", BindingFlags.SYNC_CREATE);
       view_model.bind_property("conference-type", conference_type_action, "state", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.BIDIRECTIONAL);
+      view_model.bind_property("accept-all-sensitive", reject_all, "sensitive", GLib.BindingFlags.SYNC_CREATE);
+      view_model.bind_property("reject-all-sensitive", accept_all, "sensitive", GLib.BindingFlags.SYNC_CREATE);
 
       create.clicked.connect(view_model.on_create);
+      accept_all.clicked.connect(view_model.on_accept_all);
+      reject_all.clicked.connect(view_model.on_reject_all);
+
+      if (view_model.new_conference_invite) {
+        stack.set_visible_child(conference_invite_item);
+      }
 
       var creator = new ConferenceInviteEntryCreator(logger, entry_listener);
       conference_invites.bind_model(view_model.get_list_model(), creator.create);

--- a/src/view/ErrorWidget.vala
+++ b/src/view/ErrorWidget.vala
@@ -35,6 +35,7 @@ namespace Venom {
 
     public void add_page(Gtk.Widget widget, string name, string title) {
       var scrolled_window = new Gtk.ScrolledWindow(null, null);
+      scrolled_window.get_style_context().add_class("frame");
       scrolled_window.add(widget);
       stack.add_titled(scrolled_window, name, title);
     }

--- a/src/view/FriendInfoWidget.vala
+++ b/src/view/FriendInfoWidget.vala
@@ -28,6 +28,7 @@ namespace Venom {
     [GtkChild] private Gtk.Label last_seen;
     [GtkChild] private Gtk.Entry alias;
     [GtkChild] private Gtk.Label tox_id;
+    [GtkChild] private Gtk.Image tox_identicon;
     [GtkChild] private Gtk.Switch auto_conference;
     [GtkChild] private Gtk.Switch auto_filetransfer;
     [GtkChild] private Gtk.Revealer location_revealer;
@@ -63,6 +64,7 @@ namespace Venom {
       view_model.bind_property("last-seen", last_seen, "label", BindingFlags.SYNC_CREATE);
       view_model.bind_property("last-seen-tooltip", last_seen, "tooltip-text", BindingFlags.SYNC_CREATE);
       view_model.bind_property("tox-id", tox_id, "label", BindingFlags.SYNC_CREATE);
+      view_model.bind_property("tox-identicon", tox_identicon, "pixbuf", BindingFlags.SYNC_CREATE);
 
       view_model.bind_property("alias", alias, "text", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
       view_model.bind_property("auto-conference", auto_conference, "active", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);

--- a/src/view/MessageWidget.vala
+++ b/src/view/MessageWidget.vala
@@ -27,21 +27,20 @@ namespace Venom {
     [GtkChild] private Gtk.Label timestamp;
     [GtkChild] private Gtk.Label message;
     [GtkChild] private Gtk.Image sent;
-    [GtkChild] private Gtk.Image received;
-    [GtkChild] private Gtk.Revealer additional_info;
 
     private ILogger logger;
     private MessageViewModel view_model;
     private UriTransform uri_transform;
     private PangoTransform pango_transform;
+    private ContextStyleBinding dim_binding;
 
     public MessageWidget(ILogger logger, IMessage message_content, ISettingsDatabase settings) {
       this.logger = logger;
       this.view_model = new MessageViewModel(logger, message_content, settings);
       this.uri_transform = new UriTransform(logger);
       this.pango_transform = new PangoTransform();
+      this.dim_binding = new ContextStyleBinding(sent, "dim-label");
 
-      view_model.bind_property("additional-info-visible", additional_info, "reveal-child", GLib.BindingFlags.SYNC_CREATE);
       view_model.bind_property("timestamp", timestamp, "label", GLib.BindingFlags.SYNC_CREATE);
       view_model.bind_property("timestamp-tooltip", timestamp, "tooltip-text", GLib.BindingFlags.SYNC_CREATE);
       view_model.bind_property("message", message, "label", GLib.BindingFlags.SYNC_CREATE, uri_transform.transform);
@@ -51,9 +50,8 @@ namespace Venom {
       view_model.bind_property("sender", sender, "label", GLib.BindingFlags.SYNC_CREATE, pango_transform.transform);
       view_model.bind_property("sender-sensitive", sender, "sensitive", GLib.BindingFlags.SYNC_CREATE);
       view_model.bind_property("sent-visible", sent, "visible", GLib.BindingFlags.SYNC_CREATE);
-      view_model.bind_property("received-visible", received, "visible", GLib.BindingFlags.SYNC_CREATE);
-
-      state_flags_changed.connect(() => { view_model.on_state_flags_changed(get_state_flags()); });
+      view_model.bind_property("sent-tooltip", sent, "tooltip-text", GLib.BindingFlags.SYNC_CREATE);
+      view_model.bind_property("sent-dim", dim_binding, "enable", GLib.BindingFlags.SYNC_CREATE);
 
       logger.d("MessageWidget created.");
     }

--- a/src/view/PeerEntry.vala
+++ b/src/view/PeerEntry.vala
@@ -38,8 +38,7 @@ namespace Venom {
       peer_self.visible = peer.is_self;
 
       var pub_key = Tools.hexstring_to_bin(peer.peer_key);
-      var pixbuf = Identicon.generate_pixbuf(pub_key);
-      peer_image.pixbuf = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
+      peer_image.pixbuf = round_corners(Identicon.generate_pixbuf(pub_key, 40));
       logger.d("PeerEntry created.");
     }
 
@@ -63,8 +62,7 @@ namespace Venom {
       peer_self.visible = peer.is_self;
 
       var pub_key = Tools.hexstring_to_bin(peer.peer_key);
-      var pixbuf = Identicon.generate_pixbuf(pub_key);
-      peer_image.pixbuf = round_corners(pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR));
+      peer_image.pixbuf = round_corners(Identicon.generate_pixbuf(pub_key, 20));
       logger.d("PeerEntryCompact created.");
     }
 

--- a/src/view/SettingsWidget.vala
+++ b/src/view/SettingsWidget.vala
@@ -75,7 +75,7 @@ namespace Venom {
 
       if (app_window != null) {
         app_window.reset_header_bar();
-        app_window.header_bar.title = _("Settings");
+        app_window.header_bar.title = _("Preferences");
       }
 
       stack_transform = new StackIndexTransform(stack);

--- a/src/view/WelcomeWidget.vala
+++ b/src/view/WelcomeWidget.vala
@@ -23,12 +23,28 @@ namespace Venom {
   [GtkTemplate(ui = "/chat/tox/venom/ui/welcome_widget.ui")]
   public class WelcomeWidget : Gtk.Box {
     private ILogger logger;
+    private GLib.Rand rand = new GLib.Rand();
 
-    [GtkChild]
-    private Gtk.Button link_learn_more;
+    [GtkChild] private Gtk.Button link_learn_more;
+    [GtkChild] private Gtk.Button link_get_involved;
+    [GtkChild] private Gtk.Image image;
+    [GtkChild] private Gtk.Label title;
+    [GtkChild] private Gtk.Label content;
 
-    [GtkChild]
-    private Gtk.Button link_get_involved;
+    private string[] titles = {
+      _("A new kind of instant messaging")
+    };
+
+    private string[] contents = {
+      _("Chat with your friends and family without anyone else listening in."),
+      _("Now with 50% less bugs."),
+      _("Generating witty dialog…"),
+      _("Thank you for using Venom."),
+      _("Always think positive."),
+      _("Have a good day and stay safe."),
+      _("You can do it. ― Coffee"),
+      _("Life moves pretty fast. If you don’t stop and look around once in a while, you could miss it. ― Ferris Bueller")
+    };
 
     public WelcomeWidget(ILogger logger, ApplicationWindow app_window) {
       logger.d("WelcomeWidget created.");
@@ -36,12 +52,15 @@ namespace Venom {
 
       app_window.reset_header_bar();
       app_window.header_bar.title = "Venom";
-      app_window.header_bar.subtitle = _("A new kind of instant messaging");
+      app_window.header_bar.subtitle = titles[rand.int_range(0, titles.length)];
+
+      title.set_markup(pango_big(titles[rand.int_range(0, titles.length)]));
+      content.set_markup(pango_small(contents[rand.int_range(0, contents.length)]));
 
       link_learn_more.tooltip_text = R.constants.tox_about();
-      link_learn_more.clicked.connect(on_learn_more_clicked);
-
       link_get_involved.tooltip_text = R.constants.tox_get_involved();
+
+      link_learn_more.clicked.connect(on_learn_more_clicked);
       link_get_involved.clicked.connect(on_get_involved_clicked);
     }
 
@@ -59,6 +78,14 @@ namespace Venom {
 
     private void on_get_involved_clicked() {
       try_show_uri(R.constants.tox_get_involved());
+    }
+
+    private string pango_big(string text) {
+      return @"<big>$text</big>";
+    }
+
+    private string pango_small(string text) {
+      return @"<small>$text</small>";
     }
 
     ~WelcomeWidget() {

--- a/src/viewmodel/ContactListEntryViewModel.vala
+++ b/src/viewmodel/ContactListEntryViewModel.vala
@@ -53,7 +53,7 @@ namespace Venom {
 
       var pixbuf = contact.get_image();
       if (pixbuf != null) {
-        var size = compact ? 22 : 44;
+        var size = compact ? 20 : 40;
         contact_image = round_corners(pixbuf.scale_simple(size, size, Gdk.InterpType.BILINEAR));
       }
 

--- a/src/viewmodel/ContactListViewModel.vala
+++ b/src/viewmodel/ContactListViewModel.vala
@@ -112,10 +112,14 @@ namespace Venom {
             conference_menu.append(conference.get_name_string(), @"win.invite-to-conference('$conference_id')");
           }
         }
-        menu.append_submenu(_("Invite to conference"), conference_menu);
+        menu.append_submenu(_("Invite to conference…"), conference_menu);
       }
 
       menu.append(_("Show details"), @"win.show-contact-details('$id')");
+
+      var remove_section = new GLib.Menu();
+      remove_section.append(contact.is_conference() ? _("Leave conference") : _("Remove friend"), @"win.remove-contact('$id')");
+      menu.append_section(null, remove_section);
       return menu;
     }
 
@@ -164,7 +168,7 @@ namespace Venom {
       if (pixbuf == null) {
         return null;
       }
-      return round_corners(pixbuf.scale_simple(22, 22, Gdk.InterpType.BILINEAR));
+      return round_corners(pixbuf.scale_simple(20, 20, Gdk.InterpType.BILINEAR));
     }
 
     ~ContactListViewModel() {

--- a/src/viewmodel/FriendInfoViewModel.vala
+++ b/src/viewmodel/FriendInfoViewModel.vala
@@ -28,6 +28,7 @@ namespace Venom {
     public string last_seen_tooltip { get; set; }
     public string alias { get; set; }
     public string tox_id { get; set; }
+    public Gdk.Pixbuf tox_identicon { get; set; }
     public bool auto_conference { get; set; }
     public bool auto_filetransfer { get; set; }
     public string location { get; set; }
@@ -45,8 +46,8 @@ namespace Venom {
       this.contact = contact;
       this.listener = listener;
 
-      set_info();
-      contact.changed.connect(set_info);
+      update_info();
+      contact.changed.connect(update_info);
     }
 
     private bool file_exists(string file) {
@@ -57,7 +58,7 @@ namespace Venom {
       return GLib.File.new_for_path(file).equal(File.new_for_path(R.constants.downloads_dir));
     }
 
-    private void set_info() {
+    private void update_info() {
       username = contact.name;
       statusmessage = contact.status_message;
       alias = contact.alias;
@@ -72,9 +73,10 @@ namespace Venom {
 
       show_notifications = contact._show_notifications;
       tox_id = contact.get_id();
+      tox_identicon = Identicon.generate_pixbuf(Tools.hexstring_to_bin(tox_id), 40);
       var pixbuf = contact.get_image();
       if (pixbuf != null) {
-        userimage = pixbuf.scale_simple(128, 128, Gdk.InterpType.BILINEAR);
+        userimage = pixbuf.scale_simple(120, 120, Gdk.InterpType.BILINEAR);
       }
       auto_conference = contact.auto_conference;
       auto_filetransfer = contact.auto_filetransfer;

--- a/src/viewmodel/MessageViewModel.vala
+++ b/src/viewmodel/MessageViewModel.vala
@@ -21,7 +21,6 @@
 
 namespace Venom {
   public class MessageViewModel : GLib.Object {
-    public bool   additional_info_visible { get; set; }
     public string sender { get; set; }
     public bool   sender_sensitive { get; set; }
     public Gdk.Pixbuf sender_image { get; set; }
@@ -29,7 +28,8 @@ namespace Venom {
     public string timestamp_tooltip { get; set; }
     public string message { get; set; }
     public bool   sent_visible { get; set; }
-    public bool   received_visible { get; set; }
+    public bool   sent_dim { get; set; }
+    public string sent_tooltip { get; set; }
     public string sender_color { get; set; default = ""; }
     public bool   sender_bold { get; set; default = true; }
 
@@ -70,19 +70,13 @@ namespace Venom {
       }
     }
 
-    public void on_state_flags_changed(Gtk.StateFlags flag) {
-      additional_info_visible = Gtk.StateFlags.PRELIGHT in flag || Gtk.StateFlags.SELECTED in flag;
-      if (additional_info_visible) {
-        timestamp = TimeStamp.get_pretty_timestamp(message_content.timestamp);
-      }
-    }
-
     private void on_message_changed() {
       var outoing = message_content.message_direction == MessageDirection.OUTGOING;
       sender_sensitive = !outoing;
       if (outoing) {
-        received_visible = message_content.received;
-        sent_visible = !message_content.received;
+        sent_visible = true;
+        sent_dim = !message_content.received;
+        sent_tooltip = !message_content.received ? _("Message sent ✓") : _("Message received ✓");
         sender = _("me");
       } else {
         sender = message_content.get_sender_plain();
@@ -91,9 +85,9 @@ namespace Venom {
       message = message_content.get_message_plain();
       var pixbuf = message_content.get_sender_image();
       if (pixbuf != null) {
-        sender_image = round_corners(pixbuf.scale_simple(44, 44, Gdk.InterpType.BILINEAR));
+        sender_image = round_corners(pixbuf.scale_simple(20, 20, Gdk.InterpType.BILINEAR));
       }
-      timestamp = TimeStamp.get_pretty_timestamp(message_content.timestamp);
+      timestamp = message_content.timestamp.format("%X");
       timestamp_tooltip = message_content.timestamp.format("%c");
     }
 


### PR DESCRIPTION
* Add preferences action to start from the launcher
* Add context menu option to remove contact/conference
* Add color highlight to log messages
* Add option to accept/reject all conference invites
* Fix a bug that generated identicons always in the default size
* Add mute/show conversation to notifications
* Preview peer identicons in groupchat icon
* Show conference title in notifications
* Simplify message widget layout
* Rename settings to preferences everywhere
* Show identicon next to public key in contact info
* Shrink contact images smaller in messages
* Add some more welcome messages in welcome widget
* Switch to open friend request / conference invite tab when
  new friend requests / conference invites are available
* Always show timestamp in messages on the right side