### PR TITLE
VENOM-474: Drop avatar file transfers with known hash

### DIFF
--- a/src/tox/ToxContact.vala
+++ b/src/tox/ToxContact.vala
@@ -38,7 +38,8 @@ namespace Venom {
     public string      auto_location   { get; set; default = ""; }
     // Not saved
     public bool        connected       { get; set; default = false; }
-    public Gdk.Pixbuf ? tox_image      { get; set; default = null; }
+    public Gdk.Pixbuf? tox_image       { get; set; default = null; }
+    public uint8[]?    tox_image_hash  { get; set; default = null; }
     public int         unread_messages { get; set; default = 0; }
     public bool        _is_typing      { get; set; default = false; }
     public bool        _show_notifications { get; set; default = true; }

--- a/src/tox/ToxFriendAdapter.vala
+++ b/src/tox/ToxFriendAdapter.vala
@@ -354,6 +354,7 @@ namespace Venom {
       var file = File.new_for_path(filepath);
       if (!file.query_exists()) {
         contact.tox_image = Identicon.generate_pixbuf(public_key);
+        contact.tox_image_hash = null;
       } else {
         uint8[] buf;
         try {
@@ -362,6 +363,7 @@ namespace Venom {
           pixbuf_loader.write(buf);
           pixbuf_loader.close();
           contact.tox_image = pixbuf_loader.get_pixbuf();
+          contact.tox_image_hash = ToxCore.Tox.hash(buf);
         } catch (Error e) {
           logger.i("could not read avatar data: " + e.message);
         }

--- a/src/tox/ToxSession.vala
+++ b/src/tox/ToxSession.vala
@@ -140,7 +140,7 @@ namespace Venom {
 
   public interface ToxFiletransferAdapter : GLib.Object {
     public abstract void on_file_recv_data(uint32 friend_number, uint32 file_number, uint64 file_size, string filename);
-    public abstract void on_file_recv_avatar(uint32 friend_number, uint32 file_number, uint64 file_size);
+    public abstract void on_file_recv_avatar(uint32 friend_number, uint32 file_number, uint64 file_size, uint8[] hash);
 
     public abstract void on_file_recv_chunk(uint32 friend_number, uint32 file_number, uint64 position, uint8[] data);
     public abstract void on_file_recv_control(uint32 friend_number, uint32 file_number, FileControl control);
@@ -666,7 +666,9 @@ namespace Venom {
           Idle.add(() => { session.filetransfer_listener.on_file_recv_data(friend_number, file_number, file_size, filename_str); return false; });
           break;
         case FileKind.AVATAR:
-          Idle.add(() => { session.filetransfer_listener.on_file_recv_avatar(friend_number, file_number, file_size); return false; });
+          var e = ToxCore.ErrFileGet.OK;
+          var hash = self.file_get_file_id(friend_number, file_number, out e);
+          Idle.add(() => { session.filetransfer_listener.on_file_recv_avatar(friend_number, file_number, file_size, hash); return false; });
           break;
       }
     }


### PR DESCRIPTION
* Add an `tox_image_hash` field, storing the current hash.