### PR TITLE
VENOM-481: Use compatibility fallback for v3 databases

### DIFF
--- a/src/db/DatabaseInterfaces.vala
+++ b/src/db/DatabaseInterfaces.vala
@@ -112,6 +112,10 @@ namespace Venom {
   public interface Database : GLib.Object {
   }
 
+  public interface DatabaseUpdate : GLib.Object {
+    public abstract void update_database(Database database) throws DatabaseError;
+  }
+
   public interface DatabaseStatement : GLib.Object {
     public abstract DatabaseResult step() throws DatabaseStatementError;
     public abstract void bind_text(string key, string val) throws DatabaseStatementError;


### PR DESCRIPTION
* Sqlcipher 4 uses different default settings and will fail to load
  databases created with sqlcipher 3.
* This commit will try with default settings first,
  if this fails, it will try again with PRAGMA `cipher_compatibility`
  set to 3 (see https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_compatibility).
* In the future it may be useful to provide an upgrade option in the user interface.