### PR TITLE
VENOM-482: Fix accelmods in conversations

### DIFF
--- a/src/view/ConversationWindow.vala
+++ b/src/view/ConversationWindow.vala
@@ -286,7 +286,7 @@ namespace Venom {
     public TextViewEventHandler() {
       var accel_path = "<Venom>/Message/Send";
       if (!Gtk.AccelMap.lookup_entry(accel_path, out key)) {
-        key.accel_mods = ~Gdk.ModifierType.MODIFIER_MASK;
+        key.accel_mods = 0;
         key.accel_key = Gdk.Key.Return;
         Gtk.AccelMap.add_entry(accel_path, key.accel_key, key.accel_mods);
       }


### PR DESCRIPTION
* Fixes wrong accelerator mods when trying to send a message
  for the first time in a conversation.
  Backport from #463