### PR TITLE
VENOM-487: Fix debian stable ci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,20 @@ commands:
       - run:
           name: Install meson
           command: pip3 install meson ninja
+  bootstrap-vala:
+    steps:
+      - run:
+          name: Bootstrap vala
+          command: |
+            apt remove -y valac
+            apt install -y flex bison
+            wget https://download.gnome.org/sources/vala/0.43/vala-0.43.6.tar.xz
+            tar -xJf vala-0.43.6.tar.xz
+            cd vala-0.43.6
+            ./configure --prefix=/usr --disable-valadoc
+            make
+            make install
+            cd ..
   install-toxcore:
     steps:
       - run:
@@ -108,6 +122,7 @@ jobs:
     steps:
       - checkout
       - debian-install-deps
+      - bootstrap-vala
       - install-toxcore
       - install-venom
   "Debian 10":
@@ -140,7 +155,7 @@ workflows:
     jobs:
       - "Ubuntu 18-04"
       - "Ubuntu 18-10"
-      # - "Debian 9" // FIXME requires a vala update
+      - "Debian 9"
       - "Debian 10"
       - "Fedora 28"
       - "Fedora 29"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Dependencies
 * `glib-2.0 >= 2.56`
 * `json-glib-1.0`
 * `libcanberra >= 0.30`
-* `libgee >= 0.20`
+* `libgee >= 0.18`
 * `libsoup-2.4`
 * `gspell >= 1.8`
 * `sqlcipher`

--- a/src/compat/Traversable.vala
+++ b/src/compat/Traversable.vala
@@ -1,0 +1,50 @@
+/*
+ *    Traversable.vala
+ *
+ *    Copyright (C) 2019 Venom authors and contributors
+ *
+ *    This file is part of Venom.
+ *
+ *    Venom is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Venom is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with Venom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ /* This file is partially adapted from traversable.vala in libgee
+  *
+  * Copyright (C) 2011-2012  Maciej Piechotka
+  *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Lesser General Public
+  * License as published by the Free Software Foundation; either
+  * version 2.1 of the License, or (at your option) any later version.
+
+  * This library is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  * Lesser General Public License for more details.
+
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this library; if not, write to the Free Software
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+  *
+  * Author:
+  * 	Maciej Piechotka <uzytkownik2@gmail.com>
+  */
+
+namespace Venom.Compat {
+  public static Gee.Iterator<G> order_by<G>(Gee.Traversable<G> traversable, owned CompareDataFunc<G> compare = null) {
+    var result = new Gee.ArrayList<G> ();
+    traversable.foreach ((item) => result.add(item));
+    result.sort((owned) compare);
+    return result.iterator();
+  }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,7 @@ venom_source = files(
 			'av/Pipeline.vala',
 			'av/VideoInPipeline.vala',
 			'av/VideoOutPipeline.vala',
+			'compat/Traversable.vala',
 			'core/Application.vala',
 			'core/CallState.vala',
 			'core/Contact.vala',

--- a/src/view/SettingsWidget.vala
+++ b/src/view/SettingsWidget.vala
@@ -272,7 +272,7 @@ namespace Venom {
     }
 
     private void reset_node_list() {
-      dht_nodes.set_collection(node_repository.query_all().order_by((a, b) => {
+      dht_nodes.set_collection(Compat.order_by<DhtNode>(node_repository.query_all(), (a, b) => {
         return strcmp(a.location, b.location);
       }));
       list_model = new ObservableListModel(dht_nodes);

--- a/src/view/UserInfoWidget.vala
+++ b/src/view/UserInfoWidget.vala
@@ -122,8 +122,8 @@ namespace Venom {
     }
 
     private void reset_nospam_model() {
-      var nospam_traversable = nospam_repository.query_all()
-        .order_by((a, b) => {
+      var nospam_traversable = Compat.order_by<Nospam>(nospam_repository.query_all(), 
+        (a, b) => {
           return ((Nospam)b).timestamp.compare(((Nospam)a).timestamp);
         });
       nospams.set_collection(nospam_traversable);


### PR DESCRIPTION
* Build vala from source for debian stretch
* Lower required version of `libgee-0.8` to `0.18`
  * Provide replacement for missing function `Gee.Traversable.order_by`

It may not be much, but at least this means venom builds on debian-stable.