### PR TITLE
VENOM-494: Rework message ui, improve welcome widget

### DIFF
--- a/src/ui/contact_list_widget.ui
+++ b/src/ui/contact_list_widget.ui
@@ -233,39 +233,9 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
   <object class="GtkBox" id="placeholder">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="valign">end</property>
-    <property name="margin_left">12</property>
-    <property name="border_width">6</property>
-    <property name="spacing">6</property>
     <child>
-      <object class="GtkImage">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="icon_name">pan-down-symbolic</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
+      <placeholder/>
     </child>
-    <child>
-      <object class="GtkLabel">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Add a friend</property>
-        <property name="ellipsize">end</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <style>
-      <class name="dim-label"/>
-      <class name="highlight"/>
-    </style>
   </object>
   <object class="GtkPopover" id="popover1">
     <property name="can_focus">False</property>

--- a/src/ui/custom.css
+++ b/src/ui/custom.css
@@ -95,10 +95,37 @@
   box-shadow: inset 0 -3px @borders;
 }
 
-.conversation row {
+.message {
+  background: @theme_bg_color;
+  border: 6px solid @theme_bg_color;
+  border-radius: 6px;
+}
+
+.message-arrow {
+  margin-top: 6px;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-right: 6px solid @theme_bg_color;
+}
+
+.message-arrow {
+  margin-top: 6px;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-right: 6px solid @theme_bg_color;
+}
+
+.message-arrow-outgoing {
+  margin-top: 6px;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 6px solid @theme_bg_color;
+}
+
+/* .conversation row {
   box-shadow: 0px 1px 2px 1px alpha(black, 0.2);
   margin: 1px 6px 3px 6px;
-}
+} */
 
 .separated row {
   border-bottom: 1px solid @theme_bg_color;

--- a/src/ui/message_widget.ui
+++ b/src/ui/message_widget.ui
@@ -31,15 +31,76 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="margin_left">12</property>
+        <property name="margin_right">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkImage" id="sender_image">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="valign">start</property>
-            <property name="pixel_size">20</property>
-            <property name="icon_name">user-info-symbolic</property>
-            <property name="icon_size">6</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkImage" id="sender_image">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">start</property>
+                <property name="pixel_size">20</property>
+                <property name="icon_name">user-info-symbolic</property>
+                <property name="icon_size">6</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="sender">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">sender</property>
+                <property name="use_markup">True</property>
+                <property name="ellipsize">end</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="timestamp">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">timestamp</property>
+                <property name="ellipsize">start</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage" id="sent">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="no_show_all">True</property>
+                <property name="icon_name">emblem-ok-symbolic</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -51,76 +112,18 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="sender">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label">sender</property>
-                    <property name="use_markup">True</property>
-                    <property name="ellipsize">end</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="timestamp">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label">timestamp</property>
-                    <property name="ellipsize">start</property>
-                    <style>
-                      <class name="dim-label"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkImage" id="sent">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="no_show_all">True</property>
-                    <property name="icon_name">emblem-ok-symbolic</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
+              <placeholder/>
             </child>
             <child>
-              <object class="GtkLabel" id="message">
+              <object class="GtkBox" id="arrow_incoming">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label">message</property>
-                <property name="use_markup">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap_mode">word-char</property>
-                <property name="selectable">True</property>
-                <property name="xalign">0</property>
+                <property name="valign">start</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <placeholder/>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -128,9 +131,45 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel" id="message">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">message</property>
+                <property name="use_markup">True</property>
+                <property name="wrap">True</property>
+                <property name="wrap_mode">word-char</property>
+                <property name="selectable">True</property>
+                <property name="xalign">0</property>
+                <style>
+                  <class name="message"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="arrow_outgoing">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">start</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>

--- a/src/ui/welcome_widget.ui
+++ b/src/ui/welcome_widget.ui
@@ -29,7 +29,7 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
     <property name="can_focus">False</property>
     <property name="halign">center</property>
     <property name="valign">center</property>
-    <property name="border_width">12</property>
+    <property name="border_width">6</property>
     <property name="orientation">vertical</property>
     <property name="spacing">12</property>
     <child>
@@ -37,25 +37,86 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">24</property>
         <child>
-          <object class="GtkImage" id="image">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="pixel_size">144</property>
-            <property name="icon_name">venom-symbolic</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="title">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label">&lt;big&gt;Some title&lt;/big&gt;</property>
-            <property name="use_markup">True</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <child>
+                  <object class="GtkImage" id="image">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="pixel_size">144</property>
+                    <property name="icon_name">venom</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label">&lt;span font-size='64000' font-weight='heavy'&gt;TOX&lt;/span&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="justify">center</property>
+                    <property name="wrap">True</property>
+                    <property name="yalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="title">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">title</property>
+                <property name="use_markup">True</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="content">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">content</property>
+                <property name="use_markup">True</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -64,13 +125,164 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="content">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label">Some content</property>
-            <property name="use_markup">True</property>
-            <property name="justify">center</property>
-            <property name="wrap">True</property>
+            <property name="halign">center</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">win.add_contact</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="border_width">6</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">list-add-symbolic</property>
+                        <property name="icon_size">6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Add friend</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Add a friend to your contact list</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">win.show_user</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="border_width">6</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">user-info-symbolic</property>
+                        <property name="icon_size">6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Edit profile</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Customize your profile to your liking</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -78,119 +290,11 @@ along with Venom.  If not, see <http://www.gnu.org/licenses/>.
             <property name="position">2</property>
           </packing>
         </child>
-        <style>
-          <class name="dim-label"/>
-        </style>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">center</property>
-        <property name="spacing">6</property>
-        <child>
-          <object class="GtkButton" id="link_learn_more">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">dialog-information-symbolic</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Learn more</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="link_get_involved">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">help-about-symbolic</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Get involved</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
+        <property name="position">0</property>
       </packing>
     </child>
   </template>

--- a/src/view/MessageWidget.vala
+++ b/src/view/MessageWidget.vala
@@ -1,7 +1,7 @@
 /*
  *    MessageWidget.vala
  *
- *    Copyright (C) 2013-2018 Venom authors and contributors
+ *    Copyright (C) 2013-2019 Venom authors and contributors
  *
  *    This file is part of Venom.
  *
@@ -27,6 +27,8 @@ namespace Venom {
     [GtkChild] private Gtk.Label timestamp;
     [GtkChild] private Gtk.Label message;
     [GtkChild] private Gtk.Image sent;
+    [GtkChild] private Gtk.Box arrow_incoming;
+    [GtkChild] private Gtk.Box arrow_outgoing;
 
     private Logger logger;
     private MessageViewModel view_model;
@@ -53,6 +55,15 @@ namespace Venom {
       view_model.bind_property("sent-tooltip", sent, "tooltip-text", GLib.BindingFlags.SYNC_CREATE);
       view_model.bind_property("sent-dim", dim_binding, "enable", GLib.BindingFlags.SYNC_CREATE);
       view_model.bind_property("sent-visible", sent, "visible", GLib.BindingFlags.SYNC_CREATE);
+
+      if (view_model.sender_sensitive) {
+        arrow_incoming.get_style_context().add_class("message-arrow");
+        arrow_outgoing.margin_start = 32;
+      } else {
+        arrow_outgoing.get_style_context().add_class("message-arrow-outgoing");
+        arrow_incoming.margin_start = 32;
+      }
+
 
       logger.d("MessageWidget created.");
     }

--- a/src/view/SettingsWidget.vala
+++ b/src/view/SettingsWidget.vala
@@ -149,6 +149,21 @@ namespace Venom {
       init_av_combo_with_devices(audio_out_combo, audio_out_devices);
       init_av_combo_with_devices(video_in_combo, video_in_devices);
 
+      if (audio_in_devices.is_empty) {
+        audio_in_switch.active = false;
+        audio_in_switch.sensitive = false;
+      }
+
+      if (audio_out_devices.is_empty) {
+        audio_out_switch.active = false;
+        audio_out_switch.sensitive = false;
+      }
+
+      if (video_in_devices.is_empty) {
+        video_in_switch.active = false;
+        video_in_switch.sensitive = false;
+      }
+
       update_nodes.clicked.connect(update_nodes_from_web);
 
       dht_nodes = new ObservableList();
@@ -225,7 +240,7 @@ namespace Venom {
                                                           + " t. ! queue ! audioconvert ! monoscope ! videoconvert ! gtksink name=sink");
       {
         var audioconvert = pipeline.get_by_name("ac");
-        var sink_device = audio_out_devices.@get(int.max(0, audio_out_combo.get_active() - 1));
+        var sink_device = audio_out_devices.@get(int.max(0, audio_out_combo.active - 1));
         var sink = sink_device.create_element(null);
         pipeline.add(sink);
         audioconvert.link(sink);
@@ -240,7 +255,6 @@ namespace Venom {
     }
 
     private void start_video_in_test() {
-      var source_device = video_in_devices.@get(int.max(0, video_in_combo.get_active() - 1));
       if (video_in_pipeline == null) {
         video_in_pipeline = new VideoInPipeline();
 

--- a/src/view/WelcomeWidget.vala
+++ b/src/view/WelcomeWidget.vala
@@ -25,8 +25,6 @@ namespace Venom {
     private Logger logger;
     private GLib.Rand rand = new GLib.Rand();
 
-    [GtkChild] private Gtk.Button link_learn_more;
-    [GtkChild] private Gtk.Button link_get_involved;
     [GtkChild] private Gtk.Image image;
     [GtkChild] private Gtk.Label title;
     [GtkChild] private Gtk.Label content;
@@ -51,12 +49,6 @@ namespace Venom {
       content.set_markup(pango_small(contents.@get(rand.int_range(0, contents.size))));
       image.icon_name = images.@get(rand.int_range(0, images.size));
       image.get_style_context().add_class(style_classes.@get(rand.int_range(0, style_classes.size)));
-
-      link_learn_more.tooltip_text = R.constants.tox_about();
-      link_get_involved.tooltip_text = R.constants.tox_get_involved();
-
-      link_learn_more.clicked.connect(on_learn_more_clicked);
-      link_get_involved.clicked.connect(on_get_involved_clicked);
     }
 
     private void try_show_uri(string uri) {
@@ -67,20 +59,12 @@ namespace Venom {
       }
     }
 
-    private void on_learn_more_clicked() {
-      try_show_uri(R.constants.tox_about());
-    }
-
-    private void on_get_involved_clicked() {
-      try_show_uri(R.constants.tox_get_involved());
-    }
-
     private string pango_big(string text) {
-      return @"<big>$text</big>";
+      return @"<span size='xx-large'>$text</span>";
     }
 
     private string pango_small(string text) {
-      return @"<small>$text</small>";
+      return @"<span size='large'>$text</span>";
     }
 
     ~WelcomeWidget() {


### PR DESCRIPTION
* Fix a crash in `SettingsWidget` when no camera is available
* Disable device switches if no device is available
* Change message ui to bubble style messages
* Rework `WelcomeWidget` to improve first app impressions